### PR TITLE
chore(ci): replace CODEOWNERS human reviewer with @coderabbitai

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,13 @@
 # CODEOWNERS — llm-of-qud
-# All files are owned by the repo owner. Refine per-path as the team grows.
+# CodeRabbit (GitHub App, configured by .coderabbit.yaml) handles auto review
+# for every PR. The repo owner is intentionally NOT listed here to avoid
+# redundant review requests; approval still goes through branch protection.
+#
+# Install: visit coderabbit.ai → install GitHub App → select ToaruPen/llm-of-qud
 # See docs/ci-branch-protection.md for branch protection configuration.
 
-* @ToaruPen
+* @coderabbitai
 
-# Frozen spec: extra visibility for changes to frozen architecture files
-docs/architecture-v5.md @ToaruPen
+# Frozen spec: extra CodeRabbit attention to changes against the frozen
+# architecture file (see .coderabbit.yaml path_instructions for rules).
+docs/architecture-v5.md @coderabbitai

--- a/docs/ci-branch-protection.md
+++ b/docs/ci-branch-protection.md
@@ -84,7 +84,7 @@ gh api \
 | `enforce_admins` | `true` | Admins must also go through PR flow |
 | `required_approving_review_count` | `1` | At least one human approval |
 | `dismiss_stale_reviews` | `true` | New commits invalidate prior approval |
-| `require_code_owner_reviews` | `false` | CODEOWNERS populated later; enable when ready |
+| `require_code_owner_reviews` | `false` | CODEOWNERS points to `@coderabbitai` (bot-only); enabling this setting would block merges since GitHub doesn't count bot reviews toward the code-owner requirement. Keep disabled. |
 | `require_last_push_approval` | `true` | Prevents self-approval after final push |
 | `allow_force_pushes` | `false` | Protect commit history |
 | `allow_deletions` | `false` | Protect main from accidental deletion |


### PR DESCRIPTION
## Summary

- Replace `@ToaruPen` with `@coderabbitai` in `.github/CODEOWNERS` so PR reviews are handled by the CodeRabbit GitHub App (configured in `.coderabbit.yaml`) instead of auto-pinging the repo owner.
- Update `docs/ci-branch-protection.md` to reflect the CODEOWNERS state and document why \`require_code_owner_reviews\` must stay disabled (GitHub does not count bot reviews toward the code-owner requirement).

## Why

The repo owner does not want to be auto-requested on every PR. CodeRabbit already reviews every PR via the detailed \`path_instructions\` in \`.coderabbit.yaml\`, so the reviewer slot can be routed there.

## Test plan

- [ ] Confirm the CODEOWNERS gate status check passes after the CodeRabbit App is installed on the repo.
- [ ] Confirm CodeRabbit posts a review summary on this PR itself.
- [ ] Confirm no human reviewer is auto-requested on the next fresh PR opened after merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/llm-of-qud/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
