### PR TITLE
chore(ci): teach CodeRabbit about gitignored decompiled citation convention

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,7 +41,14 @@ reviews:
         Enforce:
         - Any new CoQ API reference (type, method, event) must cite a `decompiled/` path
           and line number inline (e.g., `// decompiled/XRL/ModInfo.cs:757`). Flag
-          uncited API usage.
+          uncited API usage. Note: `decompiled/**/*.cs` and
+          `decompiled/Assembly-CSharp.csproj` are intentionally gitignored
+          (proprietary CoQ source extracted from `Assembly-CSharp.dll`, see
+          `decompiled/AGENTS.md`). The cited paths resolve only on a maintainer's
+          local CoQ install. Do NOT flag a citation as broken solely because the
+          target file is absent in hosted CI / review checkout. Flag only uncited
+          CoQ API references or malformed citations (missing file path, missing
+          line number, or wrong `decompiled/<path>.cs:<line>` shape).
         - Compile-phase log output must use `Logger.buildLog.Info(msg)` only. Runtime
           info must use `MetricsManager.LogInfo(msg)` only (mod/AGENTS.md §Logging).
           Flag any other logging call in either context.
@@ -164,5 +171,6 @@ knowledge_base:
       - "brain/AGENTS.md"
       - "docs/AGENTS.md"
       - "scripts/AGENTS.md"
+      - "decompiled/AGENTS.md"
       - "docs/architecture-v5.md"
       - "docs/adr/**/*.md"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,7 +27,13 @@ reviews:
     drafts: false
 
   path_filters:
-    - "!decompiled/**"
+    # Narrow exclusion: only the gitignored proprietary CoQ source artifacts
+    # (decompiled/**/*.cs, decompiled/Assembly-CSharp.csproj). Tracked
+    # decompiled/AGENTS.md, decompiled/CLAUDE.md, decompiled/Directory.Build.props
+    # remain reviewable AND loadable by knowledge_base.code_guidelines below
+    # (the wider "!decompiled/**" used to neutralize that load).
+    - "!decompiled/**/*.cs"
+    - "!decompiled/Assembly-CSharp.csproj"
     - "!test-results/**"
     - "!.claude/**"
     - "!build_log.txt"


### PR DESCRIPTION
## Summary
PR #4 (Phase 0-B) hit a recurring class of CodeRabbit false positive: every inline `// decompiled/<path>.cs:<line>` citation was flagged as Critical because CodeRabbit's hosted reviewer ran shell checks against the cited paths and found them missing in CI checkout. The paths are missing on purpose — `decompiled/**/*.cs` is gitignored as proprietary CoQ source per `AGENTS.md` §Imperatives item 1 and `decompiled/AGENTS.md`.

This PR teaches CodeRabbit about the convention so the next MOD PR does not hit the same finding.

Validated by Codex advisor (read-only).

## Changes
- `.coderabbit.yaml` `path_instructions` for `mod/LLMOfQud/**/*.cs`: extended the existing "must cite a decompiled path" rule with a clarifying note that the cited paths resolve only on a maintainer's local CoQ install. Hosted-CI absence is expected; flag only uncited / malformed citations.
- `.coderabbit.yaml` `knowledge_base.code_guidelines.filePatterns`: added `decompiled/AGENTS.md` so CodeRabbit reads the canonical citation-format spec as guideline context.

No source / behavior change. The MOD code and the citation form on `main` are unchanged.

## Test plan
- [ ] Pre-commit / CI green
- [ ] Next MOD PR with `decompiled/<path>.cs:<line>` citations does NOT receive a Critical "broken citation" finding from CodeRabbit
- [ ] CodeRabbit walkthrough on this PR confirms it parsed the new instructions block (look for them being acknowledged in the review summary)

## Related
- PR #4 (Phase 0-B implementation; the recurring false positive came from there)
- Issue #5 (color + glyph dictionary follow-up; will land additional MOD changes that would re-trigger the false positive without this fix)
- `decompiled/AGENTS.md` (citation format spec, now in CodeRabbit's knowledge base)
- `AGENTS.md` §Imperatives item 1 (the verify-and-cite rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/llm-of-qud/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review enforcement configuration to improve citation validation policies and automated guidance scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->