### PR TITLE
feat(mod): Phase 0-C internal-API observation (state JSON, Tasks 1-6 PASS)

### DIFF
--- a/docs/memo/phase-0-c-exit-2026-04-25.md
+++ b/docs/memo/phase-0-c-exit-2026-04-25.md
@@ -1,0 +1,172 @@
+# Phase 0-C Exit Memo (2026-04-25)
+
+## Status
+
+Phase 0-C (`docs/architecture-v5.md:2799-2816` — internal-API observation: HP, position, zone, visible entities) **PASS**. Tasks 1-6 complete. Implementation followed the approved plan (`docs/superpowers/plans/2026-04-25-phase-0-c-internal-api-observation.md`) without mid-implementation deviation; the only governance addition was ADR 0004 (deferral of C# unit-test infrastructure for `AppendJsonString` to Phase 2a). Frozen architecture-v5 spec untouched.
+
+## Environment (empirically verified 2026-04-25)
+
+| Variable | Value |
+|---|---|
+| OS | macOS Darwin 25.4.0 (Apple Silicon) |
+| `$MODS_DIR` | `$HOME/Library/Application Support/Freehold Games/CavesOfQud/Mods` |
+| `$COQ_SAVE_DIR` | `$HOME/Library/Application Support/Freehold Games/CavesOfQud` |
+| `$PLAYER_LOG` | `$HOME/Library/Logs/Freehold Games/CavesOfQud/Player.log` |
+| Mod symlink | `$MODS_DIR/LLMOfQud → ~/Dev/llm-of-qud/mod/LLMOfQud` (inherited, unchanged) |
+| Mod display | LLM of Qud (manifest unchanged, `VERSION = "0.0.1"`) |
+| Verified CoQ launch | 2026-04-25 14:37:22 local / 05:37:43 UTC (build_log + load marker) |
+| Final load order | `1: LLMOfQud` (QudJP disabled in this run — single-mod observation) |
+| ModAssembly path | `$COQ_SAVE_DIR/ModAssemblies/LLMOfQud.dll` (Roslyn output, MOD_LLMOFQUD symbol defined) |
+
+## Phase 0-C acceptance (`bash /tmp/phase-0-c-acceptance.sh` — 14 PASS / 0 FAIL / 0 WARN)
+
+### Task 4 — Roslyn compile probe (build_log.txt)
+
+```
+[2026-04-25T14:37:22] === LLM OF QUD ===
+[2026-04-25T14:37:22] Compiling 3 files...
+[2026-04-25T14:37:22] Success :)
+[2026-04-25T14:37:22] Location: …/ModAssemblies/LLMOfQud.dll
+[2026-04-25T14:37:22] Defined symbol: MOD_LLMOFQUD
+[2026-04-25T14:37:22] ==== FINAL LOAD ORDER ====
+[2026-04-25T14:37:22] 1: LLMOfQud
+[2026-04-25T14:37:43] [LLMOfQud] loaded v0.0.1 at 2026-04-25T05:37:43.8290570Z
+```
+
+`Compiling 3 files...` confirms `SnapshotState.cs` was picked up (Phase 0-B compiled 2). `Success :)` and the absence of any `COMPILER ERRORS` block confirm clean Roslyn output. The post-Bootstrap delay between compile (14:37:22) and load marker (14:37:43, ≈21 s) is the in-game embark latency, not a compile issue.
+
+### Task 5 / Task 6 — framing counts and JSON validity (Player.log)
+
+| Counter | Value |
+|---|---|
+| `INFO - [LLMOfQud][screen] BEGIN turn=` | 110 |
+| `^[LLMOfQud][screen] END turn=` (continuation, no `INFO - ` prefix) | 110 |
+| `INFO - [LLMOfQud][state] {` | 110 |
+| `INFO - [LLMOfQud][screen] ERROR turn=` | 0 |
+| `INFO - [LLMOfQud][state] ERROR turn=` | 0 |
+| `INFO - [LLMOfQud] begin_take_action count=` (every-10) | 11 (turns 10, 20, …, 110) |
+| Total Player.log size | 2,056,190 bytes / 3,323 lines |
+
+`BEGIN == END == [state] == 110`. Zero render-thread or game-thread exceptions over the full run. The Phase 0-A per-10-turns counter survives intact through the Phase 0-B + 0-C re-entries of `HandleEvent`, so 0-A correlation holds.
+
+### ADR 0004 acceptance step — manual JSON validity on the latest [state] line
+
+`turn=110` `[state]` line parses cleanly via `python3 -c "import sys, json; json.loads(sys.stdin.read())"`. Top-level keys and types:
+
+```
+{"turn": int, "player": dict, "pos": dict, "display_mode": str, "entities": list}
+turn=110
+display_mode=tile
+entities count=56
+player.hp=[20, 20]
+pos={"x": 7, "y": 9, "zone": "JoppaWorld.11.22.0.0.10"}
+```
+
+This is the gate documented in `docs/adr/0004-phase-0-c-csharp-test-infra-deferral.md` (Acceptance Step). All Phase 0-C reopen triggers in ADR 0004 evaluated negative for this run (no JSON-invalid line, no Phase 1 WebSocket boundary yet, no `AppendJsonString` regression).
+
+### First-snapshot evidence (turn=1)
+
+```
+INFO - [LLMOfQud][screen] BEGIN turn=1 w=80 h=25 mode=tile src=char:2,backup:1998,blank:0
+…ASCII grid…
+[LLMOfQud][screen] END turn=1
+INFO - [LLMOfQud][state] {"turn":1,"player":{…,"hp":[20,20]},"pos":{"x":79,"y":10,"zone":"JoppaWorld.11.22.0.1.10"},"display_mode":"tile","entities":[{"id":"e1","name":"watervine","glyph":"ô","pos":{…},"rel":{"dx":-69,"dy":-10},"distance":69,"adjacent":false,"hostile_to_player":false,"hp":[25,25]}, …]}
+```
+
+- `mode=tile` matches `display_mode=tile` in the structured frame (cross-frame consistency).
+- `src=char:2,backup:1998,blank:0` confirms the BackupChar fallback recovers ≥99 % of cells in tile mode (the 2 raw `char` cells are HUD chrome, not map cells), echoing the Phase 0-B finding.
+- `entities[0]` is a `watervine` plant at `distance=69` — the visible-and-creature-like gate is permissive on the embark zone. The schema reports `name` / `glyph` / `pos` / `rel` (player-relative) / `distance` / `adjacent` / `hostile_to_player` / `hp` exactly as planned.
+
+### Last-snapshot evidence (turn=110)
+
+```
+INFO - [LLMOfQud][screen] BEGIN turn=110 w=80 h=25 mode=tile src=char:0,backup:2000,blank:0
+```
+
+`char:0,backup:2000` for the final turn — the camera has scrolled into a region with no HUD letters in the captured rectangle, exercising the all-BackupChar branch of `SnapshotAscii`. Combined with turn=1's `char:2,backup:1998`, both branches of the Char/BackupChar fallback got real coverage during the run.
+
+## Snapshot volume (110-turn run)
+
+| Metric | Value |
+|---|---|
+| Total turns observed | 110 |
+| BEGIN markers | 110 |
+| END markers | 110 |
+| `[state]` lines | 110 |
+| ERROR markers | 0 |
+| Total Player.log bytes | 2,056,190 |
+| Bytes / snapshot (incl. ASCII grid + state JSON) | ≈ 18.7 KB |
+| Bytes / `[state]` line (turn=110, 56 entities) | ≈ 5.0 KB |
+
+The per-snapshot bytes increased from Phase 0-B's ≈ 2.05 KB to ≈ 18.7 KB. The delta is dominated by the new `[state]` JSON line (≈ 5 KB at 56 entities; turn=1 with 130 entities was larger) plus the wider `[screen] BEGIN` header. Linear projection: 1,000 turns ≈ 19 MB. Phase 1 WebSocket transport will replace `Player.log` as the primary sink, so this is a soft ceiling, not a deployment constraint.
+
+## Execution deviations from plan
+
+None at code level. Tasks 1-6 executed as written in `docs/superpowers/plans/2026-04-25-phase-0-c-internal-api-observation.md`. Governance additions made during planning, not deviations:
+
+1. **ADR 0003** (`docs/adr/0003-phase-0-a-task-7-closure-by-design.md`) closed the lingering Phase 0-A Task 7 (mid-session Mods-menu reload) by operational scope, since the streaming runtime fixes mods at launch. Four re-open triggers documented.
+2. **ADR 0004** (`docs/adr/0004-phase-0-c-csharp-test-infra-deferral.md`) deferred C# unit-test infrastructure for `AppendJsonString` to Phase 2a. The acceptance gate was substituted with the manual single-line `json.loads` check above. Six re-open triggers documented; the most likely is Phase 1 WebSocket boundary (`docs/architecture-v5.md:2399-2419`) or a single attributable JSON-invalidity surfacing in a future run.
+3. **Push gate friction** caused by multi-ADR rollups in a single push. Worked around with a rollup decision record (`docs/adr/decisions/2026-04-25-phase-0-c-readiness-rollup.md`) per the existing `2026-04-24-repo-bootstrap-push-consolidation.md` precedent. Upstream fix tracked separately (issue against `ToaruPen/ToaruPen_Template`).
+
+## Notes for downstream consumers
+
+1. **Two-LogInfo framing**: every snapshot emits exactly two top-level `MetricsManager.LogInfo` calls — one `[screen]` block (multi-line: `BEGIN` + grid + `END`) and one `[state]` line. Parsers MUST NOT assume adjacency: other CoQ subsystems can interleave `INFO - …` lines between them. Correlate by `turn=N`.
+2. **`INFO - ` prefix only on the first line** of a multi-line `LogInfo`. The `[screen] END turn=N` line is a continuation of the BEGIN call's emission and therefore appears as a bare `[LLMOfQud][screen] END turn=N` (no `INFO - `). The acceptance script anchors on `^[LLMOfQud][screen] END` for this reason. Do not add an `INFO - ` requirement to END parsers.
+3. **Single-mod run**: this acceptance was performed with QudJP disabled (final load order `1: LLMOfQud`). Phase 0-B's QudJP coexistence claim is from a separate session; we have not re-verified the multi-mod path under Phase 0-C framing. If a future phase depends on multi-mod observation, re-verify there.
+4. **Game-thread vs render-thread split** is intact: state JSON build runs in `HandleEvent(BeginTakeActionEvent)` per spec `:1787-1790`. The render thread only consumes a `PendingSnapshot` snapshot via `Interlocked.Exchange<PendingSnapshot>`. Tearing risk is therefore confined to the JSON-build path itself, which only reads game-state on the game thread.
+5. **`PendingSnapshot` ref slot** intentionally collapses the (turn, JSON) pair into one atomic publish. Any future field added to the snapshot must be threaded through this object, not added as a parallel static slot.
+6. **Visibility filter**: entity gate is `IsVisible() && (Brain != null || HasPart("Combat") || baseHitpoints > 0)`. This is permissive on Joppa (e.g. watervine passes via `baseHitpoints > 0`). If Phase 0-D restricts to "agents you can interact with this turn", tighten the gate there, not here.
+
+## Feed-forward for Phase 0-D
+
+Phase 0-D (per `docs/architecture-v5.md` Phase Plan) extends observation to `RuntimeCapabilityProfile`: mutations, abilities, cooldowns, status effects, equipment. Decompiled citations the next plan will likely need (verify before re-citing):
+
+| Concern | Suggested starting point |
+|---|---|
+| Active mutations | `decompiled/XRL.World/MutationsCollection.cs` (collection on Player) |
+| Abilities + cooldowns | `decompiled/XRL.World/ActivatedAbilityEntry.cs` + `ActivatedAbilities` part |
+| Status effects | `decompiled/XRL.World.Effects/*` (`Effect` base + collection) |
+| Equipment slots | `decompiled/XRL.World.Parts/Body.cs` + `BodyPart` slots; `Equipped` field per slot |
+| Inventory | `decompiled/XRL.World.Parts/Inventory.cs` |
+| Player capability summary | Sidebar / character sheet UI in `decompiled/XRL.UI/` (treat as reference, not API) |
+
+Open design questions for Phase 0-D planning (not for this exit memo):
+
+- Whether `RuntimeCapabilityProfile` extends the existing `[state]` line or moves to a third `[caps]` line. Risk: `[state]` payload growth (turn=1 already > 7 KB at 130 entities). If the profile is large/static, separate it.
+- Whether to emit the profile every turn (large, redundant most turns) or only when a `MutationsRecalculatedEvent` / equivalent trigger fires.
+- Whether the Brain should diff on the harness side (cheap, language-model-friendly) or the mod side (cheaper bandwidth, more code).
+
+## Open hazards (still tracked from earlier phases)
+
+- **Render-thread exception spam dedup**: zero ERROR lines over 95 turns (Phase 0-B) + 110 turns (Phase 0-C). Continue to defer dedup until/unless errors actually appear.
+- **Multi-mod coexistence under Phase 0-C framing**: untested as noted above. Not a Phase 0-C blocker; revisit when Phase 0-D or a multi-mod stream session needs it.
+
+## Files modified / created in Phase 0-C
+
+| Path | Change |
+|---|---|
+| `mod/LLMOfQud/SnapshotState.cs` | Created (~210 lines). `PendingSnapshot` class + `SnapshotState` static helpers (`AppendJsonString` with RFC 8259 escape table incl. U+2028/U+2029, `AppendAsciiSourcesJson`, `AppendEntity`, `BuildStateJson`). |
+| `mod/LLMOfQud/LLMOfQudSystem.cs` | Modified. Added `using XRL.UI;`; replaced `_pendingSnapshotTurn` int with `_pendingSnapshot` ref slot; `HandleEvent` now builds state JSON on the game thread (with try/catch sentinel); `SnapshotAscii` now returns `out int charCount, backupCount, blankCount`; `AfterRenderCallback` emits two LogInfo calls (`[screen]` BEGIN augmented with `mode=` + `src=…`, plus `[state] {…}`). |
+| `docs/superpowers/plans/2026-04-25-phase-0-c-internal-api-observation.md` | Created at the start of Phase 0-C. Reviewed across Codex Q1-Q5 + 2 plan-review passes before implementation. |
+| `docs/adr/0003-phase-0-a-task-7-closure-by-design.md` | Created. Closes Phase 0-A Task 7 by operational scope. |
+| `docs/adr/0004-phase-0-c-csharp-test-infra-deferral.md` | Created. Defers C# unit-test infra to Phase 2a; substitutes manual JSON-validity gate. |
+| `docs/adr/decision-log.md` | Updated index with ADR 0003, ADR 0004, and the Phase 0-C readiness rollup. |
+| `docs/adr/decisions/2026-04-25-phase-0-a-task-7-closure-by-operational-scope.md` | Created via `scripts/create_adr_decision.py`. |
+| `docs/adr/decisions/2026-04-25-defer-c-unit-test-infrastructure-for-phase-0-c-appendjsonstring-to-phase-2a.md` | Created via `scripts/create_adr_decision.py`. |
+| `docs/adr/decisions/2026-04-25-phase-0-c-readiness-rollup.md` | Created (manual rollup, `adr_required: false`) covering both 0003 and 0004. |
+| `docs/memo/phase-0-a-exit-2026-04-23.md` | Updated. Task 7 status DEFERRED → CLOSED (ADR 0003). |
+| `docs/memo/phase-0-c-exit-2026-04-25.md` | This file. |
+
+Per AGENTS.md §Imperatives item 5, no PR has been opened for `feat/phase-0-c-implementation` yet — that's the next step (Task 8). Commits already on `origin/feat/phase-0-c-implementation`: `1007520`, `7754f56`, `056d396`, `ab2c848`, `4f2ce93`. The exit memo + this run's evidence belong on top before opening the PR.
+
+## References
+
+- `docs/architecture-v5.md` (v5.9) — `:1787-1790` (game-thread state-build routing), `:2399-2419` (Phase 1 WebSocket boundary, ADR 0004 reopen trigger), `:2799-2816` (Phase 0-B/0-C scope)
+- `docs/superpowers/plans/2026-04-25-phase-0-c-internal-api-observation.md`
+- `docs/adr/0003-phase-0-a-task-7-closure-by-design.md`
+- `docs/adr/0004-phase-0-c-csharp-test-infra-deferral.md`
+- `docs/memo/phase-0-a-exit-2026-04-23.md` (env paths, Task 7 closure)
+- `docs/memo/phase-0-b-exit-2026-04-25.md` (BackupChar fallback rule, framing prefix observation)
+- `mod/LLMOfQud/SnapshotState.cs` — JSON build helpers
+- `mod/LLMOfQud/LLMOfQudSystem.cs` — game-thread / render-thread split
+- CoQ APIs (verify before re-citing): `decompiled/XRL.Core/XRLCore.cs:624-626, 2347-2351, 2380-2383, 2423-2426`; `decompiled/XRL.World/Zone.cs:388-398, 1982-2010, 5411-5418`; `decompiled/XRL.World/Cell.cs:210, 212, 214`; `decompiled/XRL.World/GameObject.cs:766, 1177-1213, 2972-2986, 9930-, 10887-10894`; `decompiled/XRL.UI/Options.cs:574-576`; `decompiled/MetricsManager.cs:407-409`

--- a/mod/LLMOfQud/LLMOfQudSystem.cs
+++ b/mod/LLMOfQud/LLMOfQudSystem.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using ConsoleLib.Console;
 using XRL;
 using XRL.Core;
+using XRL.UI;
 using XRL.World;
 
 namespace LLMOfQud
@@ -17,10 +18,12 @@ namespace LLMOfQud
         private static bool _afterRenderRegistered;
 
         // Snapshot request handshake between HandleEvent (game thread) and
-        // AfterRenderCallback (render thread). Non-zero = "next render should
-        // snapshot this turn number". Interlocked.Exchange on both sides gives
-        // the full memory barrier; a plain int field is sufficient.
-        private static int _pendingSnapshotTurn;
+        // AfterRenderCallback (render thread). null = no pending request.
+        // Game thread: Interlocked.Exchange a fully built PendingSnapshot.
+        // Render thread: Interlocked.Exchange to null, captures the prior value.
+        // Single class-instance keeps Turn and StateJson paired atomically;
+        // a pair of int+string slots would not be atomic across the two writes.
+        private static PendingSnapshot _pendingSnapshot;
 
         private int _beginTurnCount;
 
@@ -56,15 +59,37 @@ namespace LLMOfQud
         public override bool HandleEvent(BeginTakeActionEvent E)
         {
             _beginTurnCount++;
-            // Ask the next render to snapshot. We cannot snapshot from here:
-            // by the time HandleEvent runs, the only buffer we can reach
-            // (TextConsole.CurrentBuffer) has already gone through
-            // ScreenBuffer.Copy / ConsoleChar.Copy, which drops BackupChar.
-            // decompiled/ConsoleLib.Console/TextConsole.cs:31 (CurrentBuffer)
-            // decompiled/ConsoleLib.Console/TextConsole.cs:142-163 (DrawBuffer -> CurrentBuffer.Copy(Buffer))
-            // decompiled/ConsoleLib.Console/ScreenBuffer.cs:291-308 (Copy dispatches per-cell ConsoleChar.Copy)
-            // decompiled/ConsoleLib.Console/ConsoleChar.cs:385-400 (Copy omits BackupChar)
-            Interlocked.Exchange(ref _pendingSnapshotTurn, _beginTurnCount);
+
+            // Build the structured state JSON on the game thread. This MUST run
+            // on the game thread (not the render callback) because it reads
+            // The.Player / Zone.GetObjects() / GameObject statistics — see
+            // docs/architecture-v5.md:1787-1790 for the canonical routing rule.
+            // Reading these on the render thread risks tearing.
+            string stateJson;
+            try
+            {
+                stateJson = SnapshotState.BuildStateJson(_beginTurnCount);
+            }
+            catch (Exception ex)
+            {
+                // Mirror the AfterRenderCallback exception posture: never let
+                // observation kill the mod. Emit a sentinel JSON so the parser
+                // sees a valid line; the broader [state] line will still flow
+                // for the next turn.
+                stateJson = "{\"turn\":" + _beginTurnCount.ToString() +
+                    ",\"error\":\"" + ex.GetType().Name + "\"}";
+                MetricsManager.LogInfo(
+                    "[LLMOfQud][state] ERROR turn=" + _beginTurnCount +
+                    " " + ex.GetType().Name + ": " + ex.Message);
+            }
+
+            PendingSnapshot pending = new PendingSnapshot
+            {
+                Turn = _beginTurnCount,
+                StateJson = stateJson,
+            };
+            Interlocked.Exchange(ref _pendingSnapshot, pending);
+
             if (_beginTurnCount % 10 == 0)
             {
                 MetricsManager.LogInfo(
@@ -76,11 +101,16 @@ namespace LLMOfQud
         // Render a ScreenBuffer as an ASCII grid. Tile-mode cells hold the
         // ASCII glyph in BackupChar (written by Zone.Render when _Tile is set,
         // decompiled/XRL.World/Zone.cs:5411-5418); non-tile cells keep the
-        // glyph in Char. Fall back Char -> BackupChar -> space.
+        // glyph in Char. Fall back Char -> BackupChar -> space, and count each
+        // cell's source so AfterRenderCallback can emit ascii_sources metadata.
         // decompiled/ConsoleLib.Console/ScreenBuffer.cs:21 (Buffer[,]), :79-100 (Width/Height)
         // decompiled/ConsoleLib.Console/ConsoleChar.cs:65 (BackupChar), :116 (Char property)
-        private static string SnapshotAscii(ScreenBuffer buf)
+        private static string SnapshotAscii(
+            ScreenBuffer buf, out int charCount, out int backupCount, out int blankCount)
         {
+            charCount = 0;
+            backupCount = 0;
+            blankCount = 0;
             if (buf == null)
             {
                 return "<null-buffer>\n";
@@ -98,8 +128,25 @@ namespace LLMOfQud
                 {
                     ConsoleChar cell = buf.Buffer[x, y];
                     char c = cell.Char;
-                    if (c == '\0') c = cell.BackupChar;
-                    sb.Append(c == '\0' ? ' ' : c);
+                    if (c == '\0')
+                    {
+                        char backup = cell.BackupChar;
+                        if (backup == '\0')
+                        {
+                            blankCount++;
+                            sb.Append(' ');
+                        }
+                        else
+                        {
+                            backupCount++;
+                            sb.Append(backup);
+                        }
+                    }
+                    else
+                    {
+                        charCount++;
+                        sb.Append(c);
+                    }
                 }
                 sb.Append('\n');
             }
@@ -107,26 +154,48 @@ namespace LLMOfQud
         }
 
         // Fires on the render thread after Zone.Render but before DrawBuffer.
-        // No-op unless HandleEvent requested a snapshot. Interlocked.Exchange
-        // atomically captures-and-clears the requested turn so concurrent
-        // BeginTakeActionEvent fires cannot double-log the same snapshot.
+        // No-op unless HandleEvent published a PendingSnapshot. Interlocked.Exchange
+        // atomically captures-and-clears the slot so concurrent BeginTakeActionEvent
+        // fires cannot double-log the same snapshot. Emits two LogInfo calls per
+        // snapshot — one [screen] block (with display_mode + ascii_sources metadata)
+        // and one [state] structured line — sharing turn=N as the parser-side
+        // correlation key. The parser must NOT assume adjacency; LogInfo lines
+        // from other game subsystems can interleave between the two.
         // decompiled/MetricsManager.cs:407-409 (LogInfo -> Player.log)
+        // decompiled/XRL.UI/Options.cs:574-576 (Options.UseTiles)
         private static void AfterRenderCallback(XRLCore core, ScreenBuffer buf)
         {
-            int turn = Interlocked.Exchange(ref _pendingSnapshotTurn, 0);
-            if (turn == 0)
+            PendingSnapshot pending = Interlocked.Exchange<PendingSnapshot>(ref _pendingSnapshot, null);
+            if (pending == null)
             {
                 return;
             }
+            int turn = pending.Turn;
+            string stateJson = pending.StateJson;
             try
             {
                 int w = buf != null ? buf.Width : 0;
                 int h = buf != null ? buf.Height : 0;
-                string body = SnapshotAscii(buf);
+                int charCount, backupCount, blankCount;
+                string body = SnapshotAscii(buf, out charCount, out backupCount, out blankCount);
+                string displayMode = Options.UseTiles ? "tile" : "ascii";
+
+                // Frame 1: [screen] block, augmented with display_mode and counts
+                // on the BEGIN line. END line is unchanged from 0-B for parser
+                // continuity.
                 MetricsManager.LogInfo(
-                    "[LLMOfQud][screen] BEGIN turn=" + turn + " w=" + w + " h=" + h + "\n" +
-                    body +
+                    "[LLMOfQud][screen] BEGIN turn=" + turn +
+                    " w=" + w + " h=" + h +
+                    " mode=" + displayMode +
+                    " src=char:" + charCount + ",backup:" + backupCount + ",blank:" + blankCount +
+                    "\n" + body +
                     "[LLMOfQud][screen] END turn=" + turn);
+
+                // Frame 2: [state] structured line. Parser keys on turn=N to
+                // correlate with the [screen] block; adjacency is NOT assumed
+                // (see ADR 0004 acceptance step and docs/memo/phase-0-b-exit-
+                // 2026-04-25.md).
+                MetricsManager.LogInfo("[LLMOfQud][state] " + stateJson);
             }
             catch (Exception ex)
             {

--- a/mod/LLMOfQud/SnapshotState.cs
+++ b/mod/LLMOfQud/SnapshotState.cs
@@ -1,0 +1,224 @@
+using System.Globalization;
+using System.Text;
+using XRL;
+using XRL.UI;
+using XRL.World;
+using XRL.World.Parts;
+
+namespace LLMOfQud
+{
+    internal sealed class PendingSnapshot
+    {
+        public int Turn;
+        public string StateJson;
+    }
+
+    internal static class SnapshotState
+    {
+        // JSON string escape per RFC 8259 §7. Wrapping quotes are appended.
+        // Handles: \", \\, \b, \f, \n, \r, \t, U+0000..U+001F as \u00XX,
+        // and U+2028/U+2029 escaped to <U+2028> / <U+2029> because some downstream
+        // JSON parsers treat the raw bytes as line terminators which would
+        // break a single-line LogInfo emission.
+        internal static void AppendJsonString(StringBuilder sb, string value)
+        {
+            sb.Append('"');
+            if (value == null)
+            {
+                sb.Append('"');
+                return;
+            }
+            int len = value.Length;
+            for (int i = 0; i < len; i++)
+            {
+                char c = value[i];
+                switch (c)
+                {
+                    case '\\': sb.Append("\\\\"); break;
+                    case '"':  sb.Append("\\\""); break;
+                    case '\b': sb.Append("\\b"); break;
+                    case '\f': sb.Append("\\f"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    case '\u2028': sb.Append("\\u2028"); break;
+                    case '\u2029': sb.Append("\\u2029"); break;
+                    default:
+                        if (c < 0x20)
+                        {
+                            sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+                        break;
+                }
+            }
+            sb.Append('"');
+        }
+
+        // Small JSON object for the ascii-source counter. Takes raw counts
+        // (not a struct) so the caller can wire it into either the [screen]
+        // line metadata or a future structured framing without SnapshotState
+        // knowing about either. Currently unused — Tasks 2-3's [screen] BEGIN
+        // line uses an inline `src=char:N,backup:N,blank:N` format. Retained
+        // for Phase 0-D+ structured-framing reuse.
+        internal static void AppendAsciiSourcesJson(
+            StringBuilder sb, int charCount, int backupCount, int blankCount)
+        {
+            sb.Append("{\"char\":").Append(charCount.ToString(CultureInfo.InvariantCulture));
+            sb.Append(",\"backup_char\":").Append(backupCount.ToString(CultureInfo.InvariantCulture));
+            sb.Append(",\"blank\":").Append(blankCount.ToString(CultureInfo.InvariantCulture));
+            sb.Append('}');
+        }
+
+        // Single entity record. Caller is responsible for separating multiple
+        // records with commas. Schema:
+        //   {
+        //     "id": "e1",                  // snapshot-local; regenerated per turn
+        //     "name": "snapjaw",            // ShortDisplayNameStripped
+        //     "glyph": "s",                 // Render.RenderString first char, or "?"
+        //     "pos": {"x": 41, "y": 13},   // absolute Cell coordinates
+        //     "rel": {"dx": 1, "dy": 1},   // relative to player
+        //     "distance": 2,                // path distance via DistanceTo
+        //     "adjacent": false,            // distance == 1
+        //     "hostile_to_player": true,    // GameObject.IsHostileTowards(player)
+        //     "hp": [12, 18]                // [current, max]; null if no Statistics
+        //   }
+        // decompiled/XRL.World/GameObject.cs:766 (ShortDisplayNameStripped)
+        // decompiled/XRL.World/GameObject.cs:1177-1213 (baseHitpoints / hitpoints)
+        // decompiled/XRL.World/GameObject.cs:2972-2986 (DistanceTo(GameObject))
+        // decompiled/XRL.World/GameObject.cs:10887-10894 (IsHostileTowards)
+        // decompiled/XRL.World.Parts/Render.cs:42 (RenderString)
+        internal static void AppendEntity(
+            StringBuilder sb, int idOrdinal, GameObject player, GameObject obj)
+        {
+            Cell pCell = player?.CurrentCell;
+            Cell oCell = obj?.CurrentCell;
+            int px = pCell != null ? pCell.X : 0;
+            int py = pCell != null ? pCell.Y : 0;
+            int ox = oCell != null ? oCell.X : 0;
+            int oy = oCell != null ? oCell.Y : 0;
+            int distance = (player != null && obj != null) ? player.DistanceTo(obj) : 9999999;
+            bool adjacent = (distance == 1);
+            bool hostile = (player != null && obj != null) ? obj.IsHostileTowards(player) : false;
+            int hp = obj?.hitpoints ?? 0;
+            int hpMax = obj?.baseHitpoints ?? 0;
+            bool hasHp = (obj != null) && (hpMax > 0);
+
+            string name = obj?.ShortDisplayNameStripped ?? "<unknown>";
+            Render render = obj?.Render;
+            string glyphSource = render != null ? render.RenderString : null;
+            char glyphChar = (!string.IsNullOrEmpty(glyphSource)) ? glyphSource[0] : '?';
+
+            sb.Append("{\"id\":\"e").Append(idOrdinal.ToString(CultureInfo.InvariantCulture)).Append('"');
+            sb.Append(",\"name\":");
+            AppendJsonString(sb, name);
+            sb.Append(",\"glyph\":");
+            AppendJsonString(sb, glyphChar.ToString());
+            sb.Append(",\"pos\":{\"x\":").Append(ox.ToString(CultureInfo.InvariantCulture));
+            sb.Append(",\"y\":").Append(oy.ToString(CultureInfo.InvariantCulture)).Append('}');
+            sb.Append(",\"rel\":{\"dx\":").Append((ox - px).ToString(CultureInfo.InvariantCulture));
+            sb.Append(",\"dy\":").Append((oy - py).ToString(CultureInfo.InvariantCulture)).Append('}');
+            sb.Append(",\"distance\":").Append(distance.ToString(CultureInfo.InvariantCulture));
+            sb.Append(",\"adjacent\":").Append(adjacent ? "true" : "false");
+            sb.Append(",\"hostile_to_player\":").Append(hostile ? "true" : "false");
+            if (hasHp)
+            {
+                sb.Append(",\"hp\":[").Append(hp.ToString(CultureInfo.InvariantCulture));
+                sb.Append(',').Append(hpMax.ToString(CultureInfo.InvariantCulture)).Append(']');
+            }
+            else
+            {
+                sb.Append(",\"hp\":null");
+            }
+            sb.Append('}');
+        }
+
+        // Entry point used by HandleEvent. Returns the full state-line payload
+        // (the value of the [LLMOfQud][state] line; caller adds the prefix).
+        // Schema:
+        //   {
+        //     "turn": N,
+        //     "player": {"id": "p", "name": "@", "hp": [cur, max]},
+        //     "pos": {"x": X, "y": Y, "zone": "<ZoneID or null>"},
+        //     "display_mode": "tile" | "ascii",
+        //     "entities": [ ...AppendEntity records... ]
+        //   }
+        // decompiled/XRL/The.cs:23 (Player), :31 (ZoneManager)
+        // decompiled/XRL.World/ZoneManager.cs:58 (ActiveZone field)
+        // decompiled/XRL.World/Zone.cs:388-398 (ZoneID property), :1982-2010 (GetObjects)
+        // decompiled/XRL.World/Cell.cs:210 (X), :212 (Y), :214 (ParentZone)
+        // decompiled/XRL.UI/Options.cs:574-576 (UseTiles)
+        // decompiled/XRL.World/GameObject.cs:9930- (IsVisible)
+        internal static string BuildStateJson(int turn)
+        {
+            GameObject player = The.Player;
+            Cell pCell = player?.CurrentCell;
+            Zone zone = pCell?.ParentZone ?? The.ZoneManager?.ActiveZone;
+            string zoneId = zone?.ZoneID;
+            int px = pCell != null ? pCell.X : 0;
+            int py = pCell != null ? pCell.Y : 0;
+            int hp = player?.hitpoints ?? 0;
+            int hpMax = player?.baseHitpoints ?? 0;
+            string displayMode = Options.UseTiles ? "tile" : "ascii";
+
+            StringBuilder sb = new StringBuilder(2048);
+            sb.Append("{\"turn\":").Append(turn.ToString(CultureInfo.InvariantCulture));
+
+            // Player block.
+            sb.Append(",\"player\":{\"id\":\"p\",\"name\":");
+            AppendJsonString(sb, player?.ShortDisplayNameStripped ?? "<no-player>");
+            if (player != null && hpMax > 0)
+            {
+                sb.Append(",\"hp\":[").Append(hp.ToString(CultureInfo.InvariantCulture));
+                sb.Append(',').Append(hpMax.ToString(CultureInfo.InvariantCulture)).Append(']');
+            }
+            else
+            {
+                sb.Append(",\"hp\":null");
+            }
+            sb.Append('}');
+
+            // Position block.
+            sb.Append(",\"pos\":{\"x\":").Append(px.ToString(CultureInfo.InvariantCulture));
+            sb.Append(",\"y\":").Append(py.ToString(CultureInfo.InvariantCulture));
+            sb.Append(",\"zone\":");
+            if (zoneId != null) AppendJsonString(sb, zoneId); else sb.Append("null");
+            sb.Append('}');
+
+            // Display mode.
+            sb.Append(",\"display_mode\":");
+            AppendJsonString(sb, displayMode);
+
+            // Entities (visible, non-player, with Brain-or-Combat-or-HP).
+            sb.Append(",\"entities\":[");
+            if (zone != null && player != null)
+            {
+                int ordinal = 0;
+                foreach (GameObject obj in zone.GetObjects())
+                {
+                    if (obj == null) continue;
+                    if (obj == player) continue;
+                    if (obj.CurrentCell == null) continue;
+                    if (!obj.IsVisible()) continue;
+                    // Entity gate: must be a creature-like object. Brain present
+                    // OR HasPart("Combat") OR has positive baseHitpoints. This
+                    // excludes terrain, items, and decorative objects without
+                    // committing to a fixed taxonomy.
+                    bool isCreatureLike = (obj.Brain != null) || obj.HasPart("Combat") || obj.baseHitpoints > 0;
+                    if (!isCreatureLike) continue;
+
+                    ordinal++;
+                    if (ordinal > 1) sb.Append(',');
+                    AppendEntity(sb, ordinal, player, obj);
+                }
+            }
+            sb.Append(']');
+
+            sb.Append('}');
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Phase 0-C implementation (Tasks 1-3): adds \`SnapshotState.cs\` with \`PendingSnapshot\` ref slot + RFC 8259 JSON helpers, and rewires \`LLMOfQudSystem.HandleEvent\` to build state JSON on the game thread (per spec \`:1787-1790\`) and atomically publish via \`Interlocked.Exchange<PendingSnapshot>\` for the render-thread \`AfterRenderCallback\` to emit as a paired \`[screen]\` + \`[state]\` framing keyed by \`turn=N\`.
- Phase 0-C acceptance (Tasks 4-6): 110-turn live CoQ run on macOS — \`Compiling 3 files... Success :)\`, BEGIN==END==[state]==110, ERROR=0, latest \`[state]\` line passes \`json.loads\`, entities[] non-empty (turn=1: 130 incl. watervine; turn=110: 56 @ JoppaWorld.11.22.0.0.10). \`bash /tmp/phase-0-c-acceptance.sh\` reports 14 PASS / 0 FAIL / 0 WARN.
- Exit memo at \`docs/memo/phase-0-c-exit-2026-04-25.md\` records the empirical evidence and feed-forward citations for Phase 0-D.

## Base branch

This PR targets \`docs/phase-0-c-readiness\` (PR #7). It will auto-retarget \`main\` once #7 merges.

## Test plan

- [x] Manual Roslyn compile probe via \`build_log.txt\` (\`Compiling 3 files... Success :)\`, no \`COMPILER ERRORS\`).
- [x] 110-turn in-game run with \`Player.log\` BEGIN==END==[state]==110, ERROR=0.
- [x] Manual JSON-validity gate per ADR 0004 acceptance step (latest \`[state]\` line round-trips through \`json.loads\`).
- [x] Visible non-empty entities[] confirmed (turn=1 watervine, turn=110 56 entities).
- [x] Cross-frame \`mode=tile\` / \`display_mode=tile\` consistency.
- [x] \`AppendJsonString\` BackupChar fallback hit on both branches over the run (\`char:2,backup:1998\` at turn=1; \`char:0,backup:2000\` at turn=110).
- [x] Acceptance script: \`bash /tmp/phase-0-c-acceptance.sh\` → 14 PASS / 0 FAIL.

## Governance

- ADR 0004 (\`docs/adr/0004-phase-0-c-csharp-test-infra-deferral.md\`) defers C# unit-test infra for \`AppendJsonString\` to Phase 2a. Six explicit re-open triggers documented; the most likely is the Phase 1 WebSocket boundary (\`docs/architecture-v5.md:2399-2419\`) or a single attributable JSON-invalidity in a future run.
- ADR 0003 (\`docs/adr/0003-phase-0-a-task-7-closure-by-design.md\`) closes Phase 0-A Task 7 by operational scope (streaming runtime fixes mods at launch). Four re-open triggers documented.
- Both ADRs and the rollup decision record were already pushed under PR #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/llm-of-qud/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed tracking of character display sources (character, backup, blank) in ASCII rendering mode
  * Introduced state snapshots with structured JSON logging and dual correlated log entries per capture

* **Documentation**
  * Added Phase 0-C exit memo with operational guidance and next-step references

* **Chores**
  * Improved synchronization between game and display threads using atomic snapshots
  * Enhanced error handling for state logging and serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->