### PR TITLE
docs: Phase 1 PR-1 plan hotfix — ADR 0012 + Probe 3 split + 3 added probes + 3 risks

### DIFF
--- a/docs/adr/0011-phase-1-pr-1-scope.md
+++ b/docs/adr/0011-phase-1-pr-1-scope.md
@@ -34,7 +34,7 @@ and render fallback, so the design had to be corrected by a mid-
 implementation ADR before acceptance could be trusted. Phase 1 PR-1 has
 the same class of load-bearing claims around async `Decide`, game-thread
 blocking, disconnect pause, and reconnect wake. Those claims must be
-probed before ADR 0012 / ADR 0013 lock the durable mechanics.
+probed before ADR 0013 / ADR 0014 lock the durable mechanics.
 
 ## Decision
 
@@ -73,7 +73,7 @@ PR-1 (boundary + plumbing):
   - Disconnect = pause posture (no HeuristicPolicy fallback)
   - Reconnect-wake mechanism (Probe 8 result drives the choice)
   - Latency target: <100ms round-trip with no-LLM canned Python policy
-  Required ADRs: 0011 (PR-1 scope), 0012 (async Decide threading), 0013 (pause + reconnect)
+  Required ADRs: 0011 (PR-1 scope), 0013 (async Decide threading), 0014 (pause + reconnect)
 
 PR-2 (envelope + ops):
   - 1-B Tool call message format (request/response, v5.9 envelope)
@@ -90,10 +90,16 @@ PR-3 (idempotency, Phase 2a Gate 1 prerequisite):
 Phase 2a opens here; LLM is connected via Codex auth from PR-1.
 ```
 
-ADR 0012 (async `IDecisionPolicy.Decide` threading contract) and
-ADR 0013 (disconnect=pause plus reconnect wake) will land later:
+ADR 0013 (async `IDecisionPolicy.Decide` threading contract) and
+ADR 0014 (disconnect=pause plus reconnect wake) will land later:
 either in this readiness sequence if Task 1 probe results arrive
 cleanly, or as mid-flight ADRs in PR-1.1 using the ADR 0007 pattern.
+
+Note (added 2026-04-27 by ADR 0012): the original forward references
+to ADRs 0012 and 0013 above shift to ADR 0013 (async Decide threading)
+and ADR 0014 (disconnect=pause + reconnect wake) because ADR 0012 was
+used by the plan-hotfix landed in PR #19. ADR 0011 sealed Q1-Q5 are
+unchanged.
 
 ## Alternatives Considered
 
@@ -142,9 +148,9 @@ Harder:
 
 Re-open triggers:
 
-- If Task 1 probes falsify blocking-await viability, ADR 0012 may
+- If Task 1 probes falsify blocking-await viability, ADR 0013 may
   supersede the implementation mechanics assumed by this scope.
-- If Task 1 probes falsify pause or reconnect-wake viability, ADR 0013
+- If Task 1 probes falsify pause or reconnect-wake viability, ADR 0014
   may supersede the disconnect posture or move pause mechanics to a
   different engine path.
 - If PR-1 latency cannot meet `<100ms` with no LLM

--- a/docs/adr/0012-phase-1-pr-1-plan-hotfix-probe-set-revision.md
+++ b/docs/adr/0012-phase-1-pr-1-plan-hotfix-probe-set-revision.md
@@ -1,0 +1,139 @@
+# ADR 0012: Phase 1 PR-1 plan hotfix — probe-set revision after Codex pre-probe second-opinion
+
+Status: Accepted (2026-04-27)
+
+Amend marker: Amend v5.9
+
+## Context
+
+PR #18 merged
+`docs/superpowers/plans/2026-04-27-phase-1-pr-1-websocket-bridge.md`
+with Task 1 Probes 1, 2, 3, 6, and 8. AGENTS.md Imperative #2 states
+that `docs/superpowers/plans/*` are immutable without a new ADR under
+`docs/adr/` (`AGENTS.md:18`). CodeRabbit's path instructions likewise
+require any diff to `docs/superpowers/plans/**/*.md` to have a new ADR
+entry that references the plan filename (`.coderabbit.yaml`
+path_instructions).
+
+Before any in-game probe ran, the orchestrator asked Codex for a
+read-only second opinion. The resulting memo at
+`docs/memo/phase-1-pr-1-probe-codex-second-opinion-2026-04-27.md`
+surfaced one direct contradiction between the merged Probe 3 and ADR
+0011 §Q3 disconnect=pause posture, plus four additional load-bearing
+claims and three risks that the Plan §Risks did not name.
+
+The contradiction is mechanical, not stylistic. The merged Probe 3
+expected exactly one `[decision]` and one `[cmd]` per turn after socket
+close, which validates continued autonomous action. ADR 0011 §Q3 sealed
+the opposite: socket disconnect dispatches no `Decision`; CoQ native
+idle absorbs the pause at `PlayerTurn`. In the engine loop,
+`CommandTakeActionEvent.Check` continues only when the handler returns
+true and `PreventAction` remains false
+(`decompiled/XRL.World/CommandTakeActionEvent.cs:37-39`). If the
+player keeps energy `>= 1000`, the ActionManager player branch is
+entered (`decompiled/XRL.Core/ActionManager.cs:838`) and, on the core
+thread, calls `The.Core.PlayerTurn()`
+(`decompiled/XRL.Core/ActionManager.cs:1797-1799`). A disconnect probe
+that emits a `[decision]` and `[cmd]` therefore proves the wrong
+posture for ADR 0011 §Q3.
+
+The Codex consultation also pre-empted the Phase 0-F failure pattern
+recorded in ADR 0007: a load-bearing design was locked before the
+empirical probe invalidated it, forcing a mid-implementation ADR to
+correct the mechanics. PR-1 should not repeat that pattern when the
+contradiction is already visible from static reading.
+
+## Decision
+
+Amend only the Plan's Task 1 probe set and risk list. ADR 0011 sealed
+Q1-Q5 stand untouched.
+
+Plan changes:
+
+1. **Pre-Probe Step: Compile-time `ClientWebSocket` availability
+   sanity.**
+2. **Probe 3 split into 3a + 3b.** Probe 3a keeps timeout fallback
+   expectations; Probe 3b validates disconnect mid-Decide enters pause.
+3. **Probe A added.** Probe A covers BTA / CTA bypass timing if Probe
+   8 option (i) is ever exercised.
+4. **Probe D added.** Probe D validates save/load lifecycle for the
+   WebSocket bridge state.
+5. **Probe 8 narrowed to (iv) primary + (ii) fallback.** Option (i) is
+   not tested unless both higher-priority options fail; option (iii) is
+   rejected.
+6. **Probe E added.** Probe E validates wake-key innocuousness if Probe
+   8 chooses option (iv).
+7. **Sequencing recommendation added.** Run Compile-sanity -> 1 -> 6
+   -> 2 -> 3a -> 3b -> A -> D -> 8(iv) -> E in one primary CoQ launch,
+   with one recovery launch reserved for save/load split or 8(iv)
+   failure.
+8. **§Risks gains 3 entries.** Add C# WebSocket assembly availability,
+   bridge runtime save/load serialization, and startup race between CoQ
+   mod load and Python server readiness.
+
+Because this ADR takes the next commit-order ADR number, ADR 0011's
+future reservations shift:
+
+- Future async `IDecisionPolicy.Decide` threading contract:
+  ADR 0012 -> ADR 0013.
+- Future disconnect=pause plus reconnect wake contract:
+  ADR 0013 -> ADR 0014.
+
+## Alternatives Considered
+
+1. **Roll back PR #18 and re-issue with the corrections.** Rejected:
+   it loses the orchestration-mode plus Codex-delegate workflow
+   precedent already merged.
+2. **Leave the Probe 3 contradiction in place and address it as a
+   mid-flight ADR per ADR 0007.** Rejected: the contradiction is now
+   visible from static reading, and re-correcting after probe-phase
+   failure costs more than fixing now.
+3. **Defer the additional probes A, D, and E to PR-1.1
+   implementation.** Rejected: Probe D specifically validates the
+   `[Serializable]` save/load lifecycle, which is load-bearing for
+   PR-1.1 design. `IGameSystem` is `[Serializable]`
+   (`decompiled/XRL/IGameSystem.cs:11-12`), CoQ writes systems on save
+   (`decompiled/XRL/XRLGame.cs:1573-1582`), and calls `AfterLoad` after
+   read (`decompiled/XRL/XRLGame.cs:1818-1821`).
+
+## Consequences
+
+Easier:
+
+- The Plan is internally consistent with ADR 0011 §Q3 before any
+  in-game probe runs.
+- The Phase 0-F-style "discover contradiction during empirical run"
+  risk is reduced for PR-1.
+
+Harder:
+
+- ADR 0011's forward references to "ADR 0012 / 0013" shift to
+  "ADR 0013 / 0014". This PR handles that renumbering in ADR 0011 and
+  the Plan.
+
+Re-open triggers:
+
+- If Probe 3b empirically falsifies the disconnect=pause posture
+  (i.e. CoQ engine cannot enter a clean keyboard-wait idle from a
+  CTA-thrown `DisconnectedException` with energy intact), ADR 0014
+  (disconnect=pause / reconnect wake) may need to revisit ADR 0011 §Q3.
+
+## Supersedes
+
+None. This ADR is additive; ADR 0011 sealed Q1-Q5 stand untouched.
+
+## Related Artifacts
+
+- `docs/superpowers/plans/2026-04-27-phase-1-pr-1-websocket-bridge.md`
+  — the amended Plan.
+- `docs/memo/phase-1-pr-1-probe-codex-second-opinion-2026-04-27.md`
+  — full Codex consultation captured verbatim.
+- `docs/memo/phase-1-readiness-brainstorm-2026-04-27.md` — original
+  sealed-decisions memo.
+- `docs/adr/0011-phase-1-pr-1-scope.md` — sealed PR-1 scope; forward
+  references renumbered by this ADR.
+- `docs/adr/0007-phase-0-f-prevent-action-scoped-to-abnormal-energy.md`
+  — probe-before-lock precedent.
+- `AGENTS.md:18` — Imperative #2 mandating ADR for plan diffs.
+- `.coderabbit.yaml` path_instructions — plan-filename
+  cross-reference rule.

--- a/docs/adr/decision-log.md
+++ b/docs/adr/decision-log.md
@@ -42,3 +42,4 @@ individual decision artifact under `docs/adr/decisions/`.
 - 2026-04-27T00:11:30Z | adr_required=false | PR-G2 Devin follow-up: HeuristicPolicy [Serializable] for save/load compatibility | [details](decisions/2026-04-27-pr-g2-devin-follow-up-heuristicpolicy-serializable-for-save-load-compatibility.md)
 - 2026-04-27T11:24:30Z | adr_required=true | Add Phase 1 PR-1 readiness (Plan + ADR 0011) | [details](decisions/2026-04-27-add-phase-1-pr-1-readiness-plan-adr-0011.md)
 - 2026-04-27T12:50:59Z | adr_required=false | PR #18 Devin follow-up: ADR 0011 section ordering (Supersedes before Related Artifacts) | [details](decisions/2026-04-27-pr-18-devin-follow-up-adr-0011-section-ordering-supersedes-before-related-artifacts.md)
+- 2026-04-27T13:41:15Z | adr_required=true | Add ADR 0012 — Phase 1 PR-1 plan hotfix probe-set revision | [details](decisions/2026-04-27-add-adr-0012-phase-1-pr-1-plan-hotfix-probe-set-revision.md)

--- a/docs/adr/decisions/2026-04-27-add-adr-0012-phase-1-pr-1-plan-hotfix-probe-set-revision.md
+++ b/docs/adr/decisions/2026-04-27-add-adr-0012-phase-1-pr-1-plan-hotfix-probe-set-revision.md
@@ -1,0 +1,13 @@
+# ADR Decision Record
+
+timestamp: 2026-04-27T13:41:15Z
+change: Add ADR 0012 — Phase 1 PR-1 plan hotfix probe-set revision
+adr_required: true
+rationale: Devin review on PR #19 caught that the merged Plan was amended without an ADR per AGENTS.md Imperative #2; ADR 0012 records the amendment and renumbers ADR 0011's forward references to 0013/0014.
+files:
+  - docs/adr/0012-phase-1-pr-1-plan-hotfix-probe-set-revision.md
+  - docs/adr/0011-phase-1-pr-1-scope.md
+  - docs/superpowers/plans/2026-04-27-phase-1-pr-1-websocket-bridge.md
+adr_paths:
+  - docs/adr/0012-phase-1-pr-1-plan-hotfix-probe-set-revision.md
+  - docs/adr/0011-phase-1-pr-1-scope.md

--- a/docs/memo/phase-1-pr-1-probe-codex-second-opinion-2026-04-27.md
+++ b/docs/memo/phase-1-pr-1-probe-codex-second-opinion-2026-04-27.md
@@ -12,7 +12,7 @@ readiness PR cascade to incorporate the findings before any in-game
 probe runs.
 
 This memo captures Codex's full second-opinion content verbatim for
-traceability. Subsequent ADR 0012 / 0013 drafts must cite this memo when
+traceability. Subsequent ADR 0013 / 0014 drafts must cite this memo when
 claims it raises are referenced.
 
 ## Codex consultation prompt summary

--- a/docs/memo/phase-1-pr-1-probe-codex-second-opinion-2026-04-27.md
+++ b/docs/memo/phase-1-pr-1-probe-codex-second-opinion-2026-04-27.md
@@ -1,0 +1,193 @@
+# Phase 1 PR-1 Probe Phase — Codex Second Opinion (2026-04-27)
+
+## Context
+
+After PR #18 (Phase 1 PR-1 readiness, merged at `commit 093ac64`
+2026-04-27T12:54:31Z), the orchestrator consulted Codex (`gpt-5.5`
+advisor mode, read-only) before kicking off the Task 1 probe phase. The
+consultation surfaced one direct contradiction in the merged Plan (Probe
+3 vs ADR 0011 §Q3) and four additional load-bearing claims that the
+original probe set did not cover. The Plan was hotfixed in the same
+readiness PR cascade to incorporate the findings before any in-game
+probe runs.
+
+This memo captures Codex's full second-opinion content verbatim for
+traceability. Subsequent ADR 0012 / 0013 drafts must cite this memo when
+claims it raises are referenced.
+
+## Codex consultation prompt summary
+
+The orchestrator asked Codex five questions: (1) probe-set
+completeness, (2) instrumentation chicken-and-egg between 'no impl yet'
+and 'probes need a server', (3) Probe 8 sub-option ranking, (4)
+sequencing/batching to minimize CoQ launches, (5) risks the Plan §Risks
+section did not name.
+
+## Codex full response (verbatim from agent_message)
+
+## 1. Completeness
+
+Short answer: no. The probe set is close for ADR 0012’s “blocking CTA wait can work” claim, but it is not complete or internally consistent enough to lock ADR 0013.
+
+The biggest issue is Probe 3. As written, it expects “exactly one `[decision]` and one `[cmd]` per turn” after socket close. That is a fail-open/fallback shape, not the sealed disconnect=pause posture. ADR 0011 says socket disconnect dispatches no `Decision` and native CoQ idle absorbs the pause at `PlayerTurn` (`decompiled/XRL.Core/ActionManager.cs:1797-1799`). To enter that path from CTA, the handler must leave energy `>= 1000` and `PreventAction == false` so the branch at `decompiled/XRL.Core/ActionManager.cs:838` calls `PlayerTurn`. Current Probe 3 would instead validate continued autonomous action.
+
+Recommended fix: split Probe 3 into:
+
+- **Probe 3a: timeout fallback**: keep the “one `[decision]` + one `[cmd]`” expectation for timeout only.
+- **Probe 3b: disconnect mid-Decide enters pause**: Python closes while C# is waiting; pass means no terminal action, no stale decision, energy unchanged, `PreventAction` not set, and next engine state reaches `PlayerTurn`.
+
+Missing load-bearing claims:
+
+- **BTA/CTA bypass claim**: Probe 8 option (i) touches `BeginTakeActionEvent`, but no probe proves BTA blocking or BTA `PreventAction` does not bypass CTA semantics. BTA fires before the inner loop (`decompiled/XRL.Core/ActionManager.cs:786-800`); CTA is inside it (`decompiled/XRL.Core/ActionManager.cs:829-838`). Minimal probe: one disconnect pause via BTA instrumentation, logging BTA/CTA counts, energy before/after, and whether CTA/hostile interrupt/render fallback still occur.
+
+- **Long blocking observation-silence claim**: Probe 6 covers 200ms latency, but not the fact that no new BTA-backed observation can flush while CTA is blocked. `RenderBase()` pumps `gameQueue` only when called on the core thread (`decompiled/XRL.Core/XRLCore.cs:2517-2522`), and after-render callbacks fire only during render generation (`decompiled/XRL.Core/XRLCore.cs:2347-2351`, `decompiled/XRL.Core/XRLCore.cs:2422-2426`). Minimal probe: one 1s and one 5s Decide sleep, recording UI responsiveness, after-render backlog, and exact time from response to next `[screen]/[state]`.
+
+- **Stale response / epoch claim**: Probe 3 says no stale decision after reconnect, but PR-3 owns `action_nonce + state_version + session_epoch`. If ADR 0013 will claim stale rejection, add a Probe 7-lite: hold an old response, reconnect, send it late, and prove it is ignored. Otherwise, remove that claim from ADR 0013 for PR-1.
+
+- **Save/load bridge lifecycle**: Phase 0-G explicitly leaves save/load resilience untested. New WebSocket state makes this load-bearing because `LLMOfQudSystem` is `[Serializable]`, and CoQ saves systems via `XRLGame.SaveSystems` (`decompiled/XRL/XRLGame.cs:1573-1582`) and calls `AfterLoad` after read (`decompiled/XRL/XRLGame.cs:1818-1821`). Minimal probe: connected run -> save -> load -> reconnect -> 5 turns; verify one active client, no duplicate after-render callback, no serialized socket/thread state.
+
+- **AutoAct is not reopened by default PR-1**, because PR-1 still returns only `Move` / `AttackDirection` and does not set `AutoAct.Setting`. But if Probe 8 chooses `Keyboard.PushKey`, add a narrow wake-key probe proving the injected key does not become a terminal command or disturb AutoAct state. AutoAct interrupt is reachable after CTA when `PreventAction` stays false (`decompiled/XRL.Core/ActionManager.cs:833-837`).
+
+## 2. Instrumentation chicken-and-egg
+
+The right interpretation is **minimal-stub C#/Python first, probe second, production implementation third**.
+
+Task 1’s phrase “before production C# / Python implementation begins” should be read literally. A WebSocket round trip cannot be probed without probe harness code. The harness should be intentionally disposable or clearly marked probe-only, but it must compile and run in-game.
+
+Smallest setup sequence:
+
+1. Add `mod/LLMOfQud/BrainClient.cs`.
+   - Connects to `ws://localhost:4040`.
+   - Sends one serialized `decision_input.v1`.
+   - Receives one `decision.v1`.
+   - Supports timeout, close-before-response detection, reconnect event, and a probe-mode wake callback.
+   - Does not route tools, use DB, auth, or queue calls.
+
+2. Add `mod/LLMOfQud/WebSocketPolicy.cs`.
+   - Implements `IDecisionPolicy.Decide(DecisionInput input)`.
+   - Blocks only on the BrainClient decision future.
+   - Separates timeout from disconnect.
+   - Throws `DisconnectedException` for pause probes.
+
+3. Modify `mod/LLMOfQud/LLMOfQudSystem.cs` minimally.
+   - Swap `_policy` to the probe `WebSocketPolicy`.
+   - Add an explicit `DisconnectedException` branch before the existing broad catch/drain path.
+   - Preserve the normal CTA execution body.
+   - Add probe-only logging for energy, BTA/CTA counts, pause entry, reconnect wake.
+
+4. Add `brain/app.py`.
+   - WebSocket server on localhost:4040.
+   - Configurable phase machine: sleep duration, timeout overrun, close-before-response, late stale response, reconnect marker.
+   - No Codex auth, no SQLite, no tool envelope.
+
+5. Add a probe memo artifact.
+   - `docs/memo/phase-1-pr-1-probes-YYYY-MM-DD.md`.
+   - Record raw logs and falsification decision per probe.
+
+Before Probe 1 fires, run a compile-only sanity pass for `ClientWebSocket`. CoQ’s mod compiler references assemblies already loaded into the AppDomain (`decompiled/XRL/ModManager.cs:402-405`) and compiles mod `.cs` files through Roslyn (`decompiled/XRL/ModInfo.cs:757-771`). If `System.Net.WebSockets.ClientWebSocket` is not available in that reference set, the whole probe phase blocks before runtime.
+
+## 3. Probe 8 sub-options prior
+
+Recommended ranking:
+
+1. **(iv) `Keyboard.PushKey` wake injection**
+2. **(ii) drain energy via `PassTurn` on disconnect**
+3. **(i) block-BTA polling loop**
+4. **(iii) `PreventAction = true` with no energy drain**
+
+Rationale:
+
+1. **`Keyboard.PushKey` is the best first bet.**
+   - It matches the native idle path. `PlayerTurn` checks keyboard input (`decompiled/XRL.Core/XRLCore.cs:726`) and idles through `Keyboard.IdleWait()` while energy remains high (`decompiled/XRL.Core/XRLCore.cs:2307-2315`).
+   - `Keyboard.PushKey` enqueues under lock and signals `KeyEvent` (`decompiled/ConsoleLib.Console/Keyboard.cs:763-781`).
+   - Failure mode: the wake key is interpreted as a real player command, causing an unintended wait/move/menu action and changing energy. The probe must use the least-action key possible and assert energy unchanged until the post-reconnect decision.
+
+2. **`PassTurn` is mechanically likely to resume but violates pause semantics.**
+   - If energy is drained below 1000, the player branch at `decompiled/XRL.Core/ActionManager.cs:838` is skipped and render fallback runs at `decompiled/XRL.Core/ActionManager.cs:1806-1808`.
+   - Failure mode: it is not a true pause. Time advances, NPCs/environment can act, and repeated disconnects can become blind engine-speed waiting. Use only as fallback if native idle wake is impossible.
+
+3. **Block-BTA polling is a risky fallback, not a first choice.**
+   - BTA happens before the inner action loop (`decompiled/XRL.Core/ActionManager.cs:786-800`). Blocking there prevents the normal CTA path from even starting.
+   - If BTA returns false / `PreventAction`, ActionManager zeroes energy (`decompiled/XRL.Core/ActionManager.cs:788-791`), which is no longer “energy unchanged pause.”
+   - Failure mode: Unity/game thread appears frozen, render and queue pumping starve, and a 30s disconnect becomes unacceptable. Only test with a hard <5s watchdog.
+
+4. **`PreventAction = true` with no drain is lowest priority.**
+   - ADR 0007 already established the bad shape: `CommandTakeActionEvent.Check` returns false when `PreventAction` is set (`decompiled/XRL.World/CommandTakeActionEvent.cs:37-39`), and ActionManager immediately `continue`s (`decompiled/XRL.Core/ActionManager.cs:829-832`).
+   - Failure mode: no energy drain, no render fallback, repeated CTA loop or cadence collapse. This is the option most likely to reproduce the exact class of Phase 0-F failure.
+
+## 4. Sequencing and batching
+
+Yes, Probes 1, 2, 3, and 6 can be batched into one CoQ session if the Python server is a phase controller instead of a static server.
+
+Smallest theoretical number of CoQ launches: **one**, if Probe 8’s first wake option works and no option wedges the process.
+
+Practical recommendation: plan for **one primary launch plus one reserved recovery launch**. Run the non-destructive probes first, then Probe 8 with only the highest-priority wake option. Do not burn the same session testing low-priority freeze-prone options unless the primary option fails.
+
+Python orchestration sketch:
+
+- Start `brain/app.py --probe-script phase1-pr1`.
+- C# connects once and sends normal `decision_input.v1` requests.
+- Server maintains a request counter and phase state.
+
+Suggested order:
+
+1. **Probe 1**
+   - 25 turns at 0ms.
+   - 25 turns at 50ms.
+   - 25 turns at 100ms.
+   - 25 turns at 250ms.
+   - Response: fixed valid `Move` decision.
+
+2. **Probe 6**
+   - 60 turns at 200ms.
+   - Keep this separate from Probe 1 because the assertion is observation backlog, not just round-trip success.
+
+3. **Probe 2**
+   - 50 turns sleeping beyond timeout.
+   - C# should take timeout fallback path.
+   - This should not be conflated with socket close.
+
+4. **Probe 3 revised**
+   - Close mid-Decide.
+   - For ADR 0013: expect pause entry, not fallback action.
+   - If keeping legacy fallback Probe 3a, label it explicitly as timeout/fail-open-only and do not use it to lock disconnect=pause.
+
+5. **Probe 8**
+   - Hold disconnected for 30+ seconds.
+   - Reconnect.
+   - Try `Keyboard.PushKey` wake.
+   - Verify next BTA/CTA timing, energy unchanged until fresh decision, no stale `[decision]`/`[cmd]`.
+
+The server should support phase changes through stdin/admin command or deterministic request counts. Restarting Python between phases is acceptable, but not required. The C# side should tolerate server restart without a CoQ restart, because that is itself part of the reconnect contract.
+
+## 5. Risks the Plan does not name
+
+1. **C# WebSocket assembly availability may fail before runtime.**
+   - CoQ’s mod compiler references currently loaded AppDomain assemblies (`decompiled/XRL/ModManager.cs:402-405`) and compiles mod files via Roslyn (`decompiled/XRL/ModInfo.cs:757-771`).
+   - If `System.Net.WebSockets` / `ClientWebSocket` is not already referenceable, `BrainClient.cs` may fail to compile even though the design is sound.
+   - Add a compile probe before in-game Probe 1.
+
+2. **Bridge runtime state can corrupt save/load unless explicitly nonserialized and rehydrated.**
+   - `IGameSystem` is `[Serializable]` (`decompiled/XRL/IGameSystem.cs:11-12`).
+   - CoQ writes each system on save (`decompiled/XRL/XRLGame.cs:1573-1582`) and calls `AfterLoad` after load (`decompiled/XRL/XRLGame.cs:1818-1821`).
+   - `ClientWebSocket`, threads, tasks, cancellation tokens, and pending request maps should not live in serialized fields. Mark runtime fields `[NonSerialized]`, recreate in `AfterLoad`/registration, and probe save/load.
+
+3. **Startup race between CoQ mod load and Python server readiness.**
+   - PR-1 requires Python WebSocket on localhost:4040, with `websockets` 16.0 in the Brain stack.
+   - If CoQ connects during `RegisterPlayer` before `brain/app.py` is listening, the first turn may enter disconnect pause before Probe 1 begins.
+   - Add bounded retry/backoff and a clear `[connection_lifecycle]` log before the first CTA decision.
+
+## Disposition
+
+- Probe 3 split into 3a (timeout) + 3b (disconnect=pause) — Plan
+  Change 2.
+- Probes A (BTA/CTA bypass), D (save/load lifecycle), E (wake-key
+  innocuousness) added — Plan Changes 3, 4, 6.
+- Probe 8 narrowed to (iv) primary + (ii) fallback; (i) not tested;
+  (iii) rejected per ADR 0007 — Plan Change 5.
+- §Risks updated with 3 new entries — Plan Change 8.
+- Compile-sanity pre-probe step added — Plan Change 1.
+- Probes B (long observation silence) and C (stale response/epoch)
+  deferred: B is covered well-enough by Probe 6 + Probe D for PR-1
+  scope; C is owned by PR-3 (1-G idempotency) and need not block
+  PR-1.1.

--- a/docs/superpowers/plans/2026-04-27-phase-1-pr-1-websocket-bridge.md
+++ b/docs/superpowers/plans/2026-04-27-phase-1-pr-1-websocket-bridge.md
@@ -152,21 +152,51 @@ python3 scripts/create_adr_decision.py \
 
 **Pass criteria:**
 
-- Probes 1, 2, 3, 6, and 8 are run against minimal instrumentation
-  before production C# / Python implementation begins.
+- All probes (Compile-sanity, 1, 2, 3a, 3b, A, D, 6, 8 with E if
+  (iv) selected) must be run against minimal `probe-only`
+  instrumentation as defined in Task 2/3/4/5/6/7 SCAFFOLDING
+  (compiles + runs but does not implement tools, auth, or telemetry
+  beyond bare logging).
+- Recommended sequencing: ONE primary CoQ launch with a
+  phase-controlled Python server orchestrating Probes in order
+  Compile-sanity (build-time, before launch) -> 1 -> 6 -> 2 -> 3a ->
+  3b -> A -> D -> 8(iv) -> E. Reserve ONE recovery launch for
+  save/load split or 8(iv) failure path. Do not burn the same session
+  testing low-priority freeze-prone options.
 - Each probe records setup, raw observable, expected result, actual
-  result, and falsification action.
+  result, and falsification action in the Task 1 probe memo
+  `docs/memo/phase-1-pr-1-probes-YYYY-MM-DD.md` (replace YYYY-MM-DD
+  with the actual date when the probe phase runs).
 - No ADR 0012 / ADR 0013 claim is locked without a matching probe
-  result. If a probe fails, write the ADR in the ADR 0007 pattern:
+  result. If a probe fails, write the corrective ADR in the ADR 0007
+  pattern:
   cite the falsified claim, cite engine lines, then state the corrected
   rule.
 
 **Verification commands:**
 
 ```bash
-rg -n "Probe 1|Probe 2|Probe 3|Probe 6|Probe 8" docs/memo/phase-1-pr-1-probes-*.md
+rg -n "Compile-sanity|Probe 1|Probe 2|Probe 3a|Probe 3b|Probe A|Probe D|Probe 6|Probe 8|Probe E" docs/memo/phase-1-pr-1-probes-*.md
 pre-commit run --all-files
 ```
+
+- [ ] **Pre-Probe Step: Compile-time `ClientWebSocket` availability
+  sanity.**
+  Claim: CoQ's mod compiler references currently loaded AppDomain
+  assemblies (`decompiled/XRL/ModManager.cs:402-405`) and compiles mod
+  files via Roslyn (`decompiled/XRL/ModInfo.cs:757-771`). If
+  `System.Net.WebSockets.ClientWebSocket` is not already referenceable
+  in that set, `BrainClient.cs` cannot compile and Probe 1 cannot run.
+  Setup: write a 1-file probe stub `mod/LLMOfQud/BrainClient.cs`
+  containing only a `using System.Net.WebSockets;` and a single
+  `ClientWebSocket` field reference. Compile via the standard CoQ mod
+  load. Inspect `build_log.txt`.
+  Pass: "Compiling N files... Success :)" with no `MODWARN` /
+  `COMPILER ERRORS` lines for `LLMOfQud`.
+  If falsified: ADR 0011 must amend its assumption that
+  `ClientWebSocket` is the right C# WebSocket primitive; the impl
+  PR-1.1 may need a different library (e.g. WebSocketSharp via Harmony
+  reference, or NuGet shim).
 
 - [ ] **Probe 1: blocking WebSocket wait on CTA.**
   Setup: 100 turns with Python sleeping 0ms, 50ms, 100ms, and 250ms
@@ -186,16 +216,57 @@ pre-commit run --all-files
   If falsified: ADR 0012 must alter timeout mechanics before
   implementation continues.
 
-- [ ] **Probe 3: disconnect mid-`Decide`.**
+- [ ] **Probe 3a: timeout fallback (NOT disconnect).**
+  Setup: Python sleeps beyond timeout for 50 turns.
+  Pass: exactly one `[decision]` and one `[cmd]` per turn with
+  fallback-labeled action; `PreventAction` remains scoped to ADR 0007
+  abnormal-energy catch path; blocked-dir memory updates only after
+  failed Move with `fallback == "pass_turn"`
+  (`mod/LLMOfQud/LLMOfQudSystem.cs:259-299`).
+  If falsified: ADR 0012 must alter timeout mechanics before
+  implementation continues.
+
+- [ ] **Probe 3b: disconnect mid-Decide enters pause (sealed Q3=pause).**
   Setup: Python accepts a request, closes the socket before response,
-  and repeats over 20 turns.
-  Pass: exactly one `[decision]` and one `[cmd]` per turn, no duplicate
-  terminal action, no stale decision applied after reconnect, and
-  blocked-dir memory updates only after failed Move with
-  `fallback == "pass_turn"` as in
-  `mod/LLMOfQud/LLMOfQudSystem.cs:259-299`.
-  If falsified: ADR 0013 must specify stale response rejection or a
-  different disconnect sequence.
+  repeats over 20 turns.
+  Pass: NO `[decision]` and NO `[cmd]` line are emitted for the
+  disconnect-window turn; `Energy.Value` unchanged from pre-disconnect
+  state; `PreventAction` not set; engine reaches `PlayerTurn` and
+  enters the keyboard-wait idle path
+  (`decompiled/XRL.Core/ActionManager.cs:838,1797-1799`).
+  If falsified: ADR 0013 must specify a different pause absorber, OR
+  ADR 0011 §Q3 must be revisited (in which case escalate before
+  drafting ADR 0013).
+
+- [ ] **Probe A: BTA / CTA bypass timing if Probe 8 (i) is ever
+  exercised.**
+  Setup: instrument `HandleEvent(BeginTakeActionEvent)` and
+  `HandleEvent(CommandTakeActionEvent)` to emit per-call counts; run
+  one disconnect pause via BTA-side blocking (Probe 8 option (i) test,
+  watchdog < 5s). Observable: BTA call count, CTA call count, energy
+  before/after, presence of hostile-interrupt and render fallback.
+  Pass: BTA blocking does NOT zero energy at
+  `decompiled/XRL.Core/ActionManager.cs:788-791`, CTA branch is NOT
+  skipped on resume, render fallback at
+  `decompiled/XRL.Core/ActionManager.cs:1806-1808` still flushes.
+  If falsified: Probe 8 (i) is rejected even as a fallback, and option
+  (iv) becomes the only viable wake mechanism.
+
+- [ ] **Probe D: save/load lifecycle for the WebSocket bridge state.**
+  Phase 0-G left save/load resilience untested
+  (`docs/memo/phase-0-g-exit-2026-04-27.md` §Open hazards). The new
+  bridge re-opens this hazard because `LLMOfQudSystem` extends
+  `IGameSystem` which is `[Serializable]`
+  (`decompiled/XRL/IGameSystem.cs:11-12`); CoQ writes systems on save
+  (`decompiled/XRL/XRLGame.cs:1573-1582`) and calls `AfterLoad` after
+  read (`decompiled/XRL/XRLGame.cs:1818-1821`). Setup: connected run
+  -> save -> load -> verify reconnect -> 5 turns. Pass: exactly one
+  active `BrainClient` instance after load; no duplicate after-render
+  callback registration; no serialized socket / thread / cancellation
+  token state; first turn after load reaches normal Decide flow.
+  If falsified: `BrainClient` runtime fields must be marked
+  `[NonSerialized]` and recreated in `AfterLoad` / `RegisterPlayer`
+  (typical fix; this is a known-shape problem, not a redesign).
 
 - [ ] **Probe 6: render fallback under slow decisions.**
   Setup: 60 turns with 200ms artificial decision latency.
@@ -211,11 +282,42 @@ pre-commit run --all-files
   Pass: chosen wake resumes within one render frame, applies no stale
   action, and leaves energy unchanged from the pre-pause state.
   Sub-options to test:
-  (i) block-BTA polling loop; (ii) drain energy via `PassTurn`;
-  (iii) `PreventAction = true` with no energy drain; (iv)
-  `Keyboard.PushKey` wake injection.
+  Primary: **(iv) `Keyboard.PushKey` wake injection** — matches CoQ
+  native idle path. `PlayerTurn` checks keyboard input
+  (`decompiled/XRL.Core/XRLCore.cs:726`) and idles via
+  `Keyboard.IdleWait()` while energy is high
+  (`decompiled/XRL.Core/XRLCore.cs:2307-2315`); `Keyboard.PushKey`
+  enqueues under lock and signals `KeyEvent`
+  (`decompiled/ConsoleLib.Console/Keyboard.cs:763-781`). Failure mode
+  = wake key is interpreted as a real player command; mitigated by
+  Probe E (next change) which proves the chosen wake key is innocuous.
+  Fallback: **(ii) drain energy via `PassTurn` on disconnect** — only
+  if (iv) is empirically falsified. Trade-off: not a true pause; time
+  advances and NPCs/environment can act, so the disconnect window
+  grants other actors free turns.
+  NOT TESTED: **(i) block-BTA polling loop** — Unity main-thread freeze
+  risk per Probe A above; would be tested only if BOTH (iv) and (ii)
+  fail.
+  REJECTED: **(iii) `PreventAction = true` with no energy drain** —
+  same shape as the Phase 0-F failure that ADR 0007 corrected
+  (`decompiled/XRL.World/CommandTakeActionEvent.cs:37-39` returns
+  false; ActionManager continues at
+  `decompiled/XRL.Core/ActionManager.cs:829-832`).
   If falsified: ADR 0013 must choose a different pause absorber or
   reconnect wake mechanism before Task 4 proceeds.
+
+- [ ] **Probe E: wake-key innocuousness (fires only if Probe 8 chooses
+  option (iv)).**
+  Setup: select the most innocuous `Keys` enum value available (e.g.
+  an unmapped diagnostic key, NOT `Space` / `Enter` / a movement key);
+  inject via `Keyboard.PushKey` from the BrainClient reconnect
+  callback; observe over 20 reconnect cycles.
+  Pass: injected key is NOT interpreted as a player command (no
+  `[cmd]` line, no movement, no menu open); `Energy.Value` unchanged
+  across the wake; next CTA fires from the post-reconnect Python
+  decision, not from the wake key.
+  If falsified: choose a different key OR fall back to Probe 8 option
+  (ii).
 
 ## Task 2: `BrainClient.cs` skeleton
 
@@ -463,3 +565,25 @@ the full `tool_call` / `tool_result` envelope portion lands in PR-2.
 - **SQLite schema churn:** PR-1 telemetry tables precede the PR-2
   envelope lock, so `decision_request` / `decision_response` columns may
   churn when `tool_call` / `tool_result` becomes authoritative.
+- **C# WebSocket assembly availability may fail before runtime.** CoQ's
+  mod compiler references currently loaded AppDomain assemblies
+  (`decompiled/XRL/ModManager.cs:402-405`) and compiles mod files via
+  Roslyn (`decompiled/XRL/ModInfo.cs:757-771`). If
+  `System.Net.WebSockets` / `ClientWebSocket` is not already
+  referenceable, `BrainClient.cs` may fail to compile even though the
+  design is sound. Mitigated by the Pre-Probe compile-sanity step.
+- **Bridge runtime state can corrupt save/load unless explicitly
+  nonserialized and rehydrated.** `IGameSystem` is `[Serializable]`
+  (`decompiled/XRL/IGameSystem.cs:11-12`). CoQ writes each system on
+  save (`decompiled/XRL/XRLGame.cs:1573-1582`) and calls `AfterLoad`
+  after load (`decompiled/XRL/XRLGame.cs:1818-1821`).
+  `ClientWebSocket`, threads, tasks, cancellation tokens, and pending
+  request maps must NOT live in serialized fields. Mark runtime fields
+  `[NonSerialized]`; recreate in `AfterLoad` / `RegisterPlayer`.
+  Validated by Probe D.
+- **Startup race between CoQ mod load and Python server readiness.**
+  PR-1 requires Python WebSocket on `localhost:4040` with `websockets`
+  16.0. If CoQ connects during `RegisterPlayer` before `brain/app.py`
+  is listening, the first turn enters disconnect=pause before Probe 1
+  begins. Mitigated by bounded retry/backoff in BrainClient and a clear
+  `[connection_lifecycle]` log line before the first CTA decision.

--- a/docs/superpowers/plans/2026-04-27-phase-1-pr-1-websocket-bridge.md
+++ b/docs/superpowers/plans/2026-04-27-phase-1-pr-1-websocket-bridge.md
@@ -20,7 +20,7 @@ for O(timeout) on a `Task` completed by `BrainClient`, while
 `BrainClient` owns socket connect, send, receive, and reconnect detection
 on a dedicated non-game thread. The disconnect path is sealed as pause,
 not runtime `HeuristicPolicy` fallback, but the exact pause/wake mechanism
-is probe-driven by Task 1 and ADR 0013.
+is probe-driven by Task 1 and ADR 0014.
 
 **Tech Stack:** C# in the existing Roslyn-compiled CoQ MOD; Python 3.13
 with uv, `websockets` 16.0, `aiosqlite`, and `structlog` per
@@ -45,7 +45,7 @@ with uv, `websockets` 16.0, `aiosqlite`, and `structlog` per
 - **PR convergence**: PR-1.0 is this readiness PR: plan, ADR 0011,
   decision-log entry, decision record, and the sealed-decisions memo.
   It merges first. Implementation PR-1.1 opens only after Task 1 probe
-  results either lock ADR 0012 / ADR 0013 or force mid-flight ADRs using
+  results either lock ADR 0013 / ADR 0014 or force mid-flight ADRs using
   the ADR 0007 precedent.
 - **Phase 1 PR cascade**: PR-1.0 -> PR-1.1 -> PR-2 -> PR-3 -> Phase 2a.
 - **Probe-before-lock rule**: ADR 0007 exists because an empirical probe
@@ -54,7 +54,7 @@ with uv, `websockets` 16.0, `aiosqlite`, and `structlog` per
   PR-1 treats Probes 1, 2, 3, 6, and 8 from
   `docs/memo/phase-1-readiness-brainstorm-2026-04-27.md` §5 as Task 1
   gates. No C# or Python implementation proceeds until those probes pass
-  or the design pivots through ADR 0012 / ADR 0013.
+  or the design pivots through ADR 0013 / ADR 0014.
 
 ## Files affected
 
@@ -145,8 +145,8 @@ python3 scripts/create_adr_decision.py \
 **Files modified:**
 
 - Create: `docs/memo/phase-1-pr-1-probes-YYYY-MM-DD.md`
-- Create if probes pass cleanly: `docs/adr/0012-*.md`
 - Create if probes pass cleanly: `docs/adr/0013-*.md`
+- Create if probes pass cleanly: `docs/adr/0014-*.md`
 - Create mid-flight replacement ADRs if any probe falsifies a
   load-bearing claim.
 
@@ -167,7 +167,7 @@ python3 scripts/create_adr_decision.py \
   result, and falsification action in the Task 1 probe memo
   `docs/memo/phase-1-pr-1-probes-YYYY-MM-DD.md` (replace YYYY-MM-DD
   with the actual date when the probe phase runs).
-- No ADR 0012 / ADR 0013 claim is locked without a matching probe
+- No ADR 0013 / ADR 0014 claim is locked without a matching probe
   result. If a probe fails, write the corrective ADR in the ADR 0007
   pattern:
   cite the falsified claim, cite engine lines, then state the corrected
@@ -204,7 +204,7 @@ pre-commit run --all-files
   Pass: one `[decision]` and one `[cmd]` per CTA; `[screen]`,
   `[state]`, `[caps]`, and `[build]` remain correlated by turn; no
   keyboard prompt.
-  If falsified: ADR 0012 must reject blocking `Decide` as the durable
+  If falsified: ADR 0013 must reject blocking `Decide` as the durable
   model and choose prefetch, queue routing, or continuation with new
   probes.
 
@@ -213,7 +213,7 @@ pre-commit run --all-files
   Pass: fallback-labeled `[decision]` and `[cmd]` lines show accepted
   energy drain or accepted negative energy; `PreventAction` remains
   scoped to the ADR 0007 abnormal-energy catch path.
-  If falsified: ADR 0012 must alter timeout mechanics before
+  If falsified: ADR 0013 must alter timeout mechanics before
   implementation continues.
 
 - [ ] **Probe 3a: timeout fallback (NOT disconnect).**
@@ -223,7 +223,7 @@ pre-commit run --all-files
   abnormal-energy catch path; blocked-dir memory updates only after
   failed Move with `fallback == "pass_turn"`
   (`mod/LLMOfQud/LLMOfQudSystem.cs:259-299`).
-  If falsified: ADR 0012 must alter timeout mechanics before
+  If falsified: ADR 0013 must alter timeout mechanics before
   implementation continues.
 
 - [ ] **Probe 3b: disconnect mid-Decide enters pause (sealed Q3=pause).**
@@ -234,9 +234,9 @@ pre-commit run --all-files
   state; `PreventAction` not set; engine reaches `PlayerTurn` and
   enters the keyboard-wait idle path
   (`decompiled/XRL.Core/ActionManager.cs:838,1797-1799`).
-  If falsified: ADR 0013 must specify a different pause absorber, OR
+  If falsified: ADR 0014 must specify a different pause absorber, OR
   ADR 0011 §Q3 must be revisited (in which case escalate before
-  drafting ADR 0013).
+  drafting ADR 0014).
 
 - [ ] **Probe A: BTA / CTA bypass timing if Probe 8 (i) is ever
   exercised.**
@@ -272,7 +272,7 @@ pre-commit run --all-files
   Setup: 60 turns with 200ms artificial decision latency.
   Pass: each completed decision has exactly one action and one
   observation set; observations do not bunch after many turns.
-  If falsified: ADR 0012 must reject or narrow game-thread blocking.
+  If falsified: ADR 0013 must reject or narrow game-thread blocking.
 
 - [ ] **Probe 8: reconnect wake mechanism.**
   Setup: hold WebSocket disconnected for 30+ seconds, observe CoQ
@@ -303,7 +303,7 @@ pre-commit run --all-files
   (`decompiled/XRL.World/CommandTakeActionEvent.cs:37-39` returns
   false; ActionManager continues at
   `decompiled/XRL.Core/ActionManager.cs:829-832`).
-  If falsified: ADR 0013 must choose a different pause absorber or
+  If falsified: ADR 0014 must choose a different pause absorber or
   reconnect wake mechanism before Task 4 proceeds.
 
 - [ ] **Probe E: wake-key innocuousness (fires only if Probe 8 chooses
@@ -389,7 +389,7 @@ pre-commit run --all-files
   construction aid; runtime disconnect does not continue autonomous
   actions through it.
 - `DisconnectedException` enters the Task 1 Probe 8 pause posture.
-- Reconnect-wake hook is implemented by the ADR 0013 mechanism.
+- Reconnect-wake hook is implemented by the ADR 0014 mechanism.
 - ADR 0007 scope remains unchanged: `PreventAction` is not used on
   the success path, and the render fallback at
   `decompiled/XRL.Core/ActionManager.cs:1806-1808` remains load-bearing.
@@ -527,7 +527,7 @@ uv run pytest tests/
 **Pass criteria:**
 
 - Memo follows the Phase 0-G exit-memo style.
-- Includes probe outcomes, ADR 0012 / 0013 status, acceptance metrics,
+- Includes probe outcomes, ADR 0013 / 0014 status, acceptance metrics,
   known deferrals, and PR-2 handoff.
 - Calls out any schema or envelope facts that remain intentionally
   deferred.


### PR DESCRIPTION
## Summary

Pre-probe-phase hotfix to the Phase 1 PR-1 implementation plan merged in PR #18, **recorded by ADR 0012** per `AGENTS.md` Imperative #2 (Plan diffs require an ADR). Codex advisor (`gpt-5.5`, read-only) was consulted before the orchestrator kicked off the Task 1 probe phase, and surfaced **one direct contradiction** between merged Probe 3 and ADR 0011 §Q3 (disconnect=pause), plus 4 additional load-bearing claims and 3 risks the original Plan §Risks did not name.

This PR is **docs-only** and does not change ADR 0011's sealed Q1-Q5. ADR 0012 amends only the Plan and renumbers ADR 0011's forward references (ADR 0012/0013 → ADR 0013/0014) so the future async-Decide and disconnect-pause ADRs land at their natural commit-order numbers.

## ADR cross-reference

- **ADR 0012** ([docs/adr/0012-phase-1-pr-1-plan-hotfix-probe-set-revision.md](https://github.com/ToaruPen/llm-of-qud/blob/docs/phase-1-pr-1-plan-hotfix/docs/adr/0012-phase-1-pr-1-plan-hotfix-probe-set-revision.md)) records the decision to amend `docs/superpowers/plans/2026-04-27-phase-1-pr-1-websocket-bridge.md` with the 8 changes below.

## Key fix: Probe 3 split

The merged Probe 3 expected "exactly one [decision] and one [cmd] per turn" after socket close. ADR 0011 §Q3 says the opposite: on disconnect, no Decision is dispatched and CoQ native idle absorbs the pause at PlayerTurn. Probe 3 is split into:

- **Probe 3a (timeout fallback)** — keeps the original 1-action-per-turn assertion for the timeout case.
- **Probe 3b (disconnect=pause)** — NO [decision]/[cmd] for the disconnect-window turn, energy unchanged, PreventAction not set, engine reaches PlayerTurn keyboard wait.

## Plan changes (8 total, recorded by ADR 0012)

1. **Pre-Probe Step** — compile-time `ClientWebSocket` availability sanity check.
2. **Probe 3 split** — 3a (timeout) + 3b (disconnect=pause).
3. **Probe A** (NEW) — BTA/CTA bypass timing.
4. **Probe D** (NEW) — save/load lifecycle for the bridge state ([Serializable] LLMOfQudSystem).
5. **Probe 8 narrowed** — (iv) Keyboard.PushKey primary, (ii) PassTurn fallback. (i) block-BTA not tested unless both fail; (iii) PreventAction-without-drain rejected per ADR 0007.
6. **Probe E** (NEW) — wake-key innocuousness, fires only if Probe 8 selects (iv).
7. **Sequencing recommendation** — Compile-sanity → 1 → 6 → 2 → 3a → 3b → A → D → 8(iv) → E in one primary CoQ launch + one reserved recovery launch.
8. **§Risks** — 3 new entries: ClientWebSocket assembly availability, [Serializable] save/load corruption, CoQ-mod ↔ Python-server startup race.

## ADR 0011 forward-reference renumbering

Original ADR 0011 §Decision pencil-reserved ADR 0012 (async Decide threading) and ADR 0013 (disconnect=pause + reconnect wake). ADR 0012 takes the plan-hotfix slot, so the future ADRs shift:

- ADR 0013 — async `IDecisionPolicy.Decide` threading contract (lands after Task 1 probes 1, 6, 2, 3a, A complete).
- ADR 0014 — disconnect=pause + reconnect-wake mechanism (lands after Probes 3b, 8, E complete).

A renumbering note is added inline in ADR 0011's Decision section. Sealed Q1-Q5 are unchanged.

## Memo deliverable

`docs/memo/phase-1-pr-1-probe-codex-second-opinion-2026-04-27.md` captures the Codex advisor consultation verbatim for traceability. Future ADR 0013 / 0014 drafts will cite this memo when claims it raises are referenced.

## What is NOT changed

- ADR 0011 sealed Q1-Q5 stand untouched.
- `docs/architecture-v5.md` (frozen at v5.9 per ADR 0001) is not edited.
- No code changes; impl PR-1.1 still gated on the (now corrected) probe phase.

## Test plan

- [x] CI all SUCCESS (markdown-lint, ADR checks, frozen-file-guard, harness-lint, secretlint, pre-commit-meta, required-checks-gate, GitGuardian)
- [x] ADR cross-reference added to PR body per `.coderabbit.yaml` path_instructions for `docs/superpowers/plans/**/*.md`
- [x] Devin 🔴 governance finding addressed (ADR 0012 created, AGENTS.md Imperative #2 satisfied)
- [ ] CodeRabbit re-review on the latest commit passes
- [ ] Reviewer agrees ADR 0012 captures the amendment correctly + renumbering note in ADR 0011 is sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a probe review memo that records findings, gaps, risk items, and prioritized disposition actions for Phase 1 PR-1.
  * Revised planning ADRs and the empirical gating plan: expanded probe coverage and sequencing, split disconnect tests into 3a/3b, tightened Probe 8 wake/fallback rules, and added save/load and startup race safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->