### PR TITLE
Phase 1 PR-3: add terminal action idempotency

### DIFF
--- a/brain/app.py
+++ b/brain/app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import signal
 import sys
@@ -17,8 +18,14 @@ import structlog
 from pydantic import BaseModel, ConfigDict, Field
 from websockets.asyncio.server import Server, ServerConnection, serve
 
-from brain.protocol import JsonObject as ProtocolJsonObject
-from brain.protocol import ToolCallMessage, ToolResultMessage
+from brain.protocol import (
+    JsonObject as ProtocolJsonObject,
+)
+from brain.protocol import (
+    ToolCallMessage,
+    ToolResultMessage,
+    is_terminal_action_tool,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -219,6 +226,7 @@ class DecisionRequest(BaseModel):
     turn: int
     request_schema: str = Field(alias="schema")
     summary: DecisionInputSummary
+    snapshot_hash: str
 
 
 async def respond_for_phase(
@@ -236,10 +244,13 @@ async def respond_for_phase(
     if is_tool_call_probe_phase(phase):
         result = await emit_probe_tool_call(connection, request, phase)
         response = canned_decision(request, phase)
-        response["tool_result"] = cast(
-            "JsonValue",
+        tool_result_payload = cast(
+            "ProtocolJsonObject",
             result.result.model_dump(mode="json", exclude_none=True),
         )
+        if result.action_nonce is not None:
+            tool_result_payload["action_nonce"] = result.action_nonce
+        response["tool_result"] = cast("JsonValue", tool_result_payload)
         await connection.send(json.dumps(response, separators=(",", ":")))
         logger.info("decision_response", turn=request.turn, delay_ms=0)
         return "normal"
@@ -282,6 +293,7 @@ async def emit_probe_tool_call(
         [{"tool": tool, "args": args}],
         turn=request.turn,
         session_epoch=PROBE_SESSION_EPOCH,
+        snapshot_hash=request.snapshot_hash,
     )
     return await emit_tool_call(connection, tool_call)
 
@@ -322,6 +334,15 @@ def require_matching_tool_result(
             tool_call.session_epoch,
             tool_result.session_epoch,
         )
+    if (
+        is_terminal_action_tool(tool_call.tool)
+        and tool_result.action_nonce != tool_call.action_nonce
+    ):
+        raise ToolResultMismatchError(
+            "action_nonce",
+            tool_call.action_nonce,
+            tool_result.action_nonce,
+        )
 
 
 def build_tool_call_messages(
@@ -329,6 +350,7 @@ def build_tool_call_messages(
     *,
     turn: int,
     session_epoch: int,
+    snapshot_hash: str | None = None,
 ) -> tuple[ToolCallMessage, ...]:
     tool_names = [
         require_provider_tool_name(call, index)
@@ -347,16 +369,22 @@ def build_tool_call_messages(
         if call_id in seen_call_ids:
             raise DuplicateToolCallIdError(call_id)
         seen_call_ids.add(call_id)
+        terminal_action = is_terminal_action_tool(tool)
+        args = require_protocol_json_object(
+            call.get("args", {}),
+            f"provider_tool_calls[{index}].args",
+        )
+        if terminal_action and snapshot_hash is not None:
+            args = args | {"snapshot_hash": snapshot_hash}
         messages.append(
             ToolCallMessage(
                 call_id=call_id,
                 tool=tool,
-                args=require_protocol_json_object(
-                    call.get("args", {}),
-                    f"provider_tool_calls[{index}].args",
-                ),
+                args=args,
                 message_id=f"msg-{turn}-tool-call-{index}",
                 session_epoch=session_epoch,
+                action_nonce=f"turn-{turn}-{tool}-nonce" if terminal_action else None,
+                state_version=turn if terminal_action else None,
             ),
         )
     return tuple(messages)
@@ -487,6 +515,7 @@ def parse_decision_input(message: str | bytes) -> DecisionRequest:
     return DecisionRequest(
         turn=turn,
         schema=schema,
+        snapshot_hash=decision_input_snapshot_hash(message),
         summary=DecisionInputSummary(
             hp=optional_int(player, "hp"),
             max_hp=optional_int(player, "max_hp"),
@@ -495,6 +524,11 @@ def parse_decision_input(message: str | bytes) -> DecisionRequest:
             blocked_dirs_count=len(blocked_dir_strings),
         ),
     )
+
+
+def decision_input_snapshot_hash(message: str | bytes) -> str:
+    data = message.encode("utf-8") if isinstance(message, str) else message
+    return hashlib.sha256(data).hexdigest()
 
 
 def is_json_object(value: object) -> TypeGuard[dict[str, JsonValue]]:

--- a/brain/app.py
+++ b/brain/app.py
@@ -44,7 +44,6 @@ MALFORMED_TOOL_ARGS_ERROR_CODE = "invalid_tool_args"
 ACCEPTANCE_DISCONNECT_REQUEST = 6
 EXPLORE_DIR_ORDER = ("E", "SE", "NE", "S", "N", "W", "SW", "NW")
 VALID_COMPASS_DIRS = frozenset(EXPLORE_DIR_ORDER)
-TERMINAL_ACTIONS = frozenset({"execute", "navigate_to", "choose"})
 PROBE_SESSION_EPOCH = 1
 SCRIPT_PROBE_1_TURNS = 25
 SCRIPT_PROBE_6_END = 160
@@ -356,7 +355,7 @@ def build_tool_call_messages(
         require_provider_tool_name(call, index)
         for index, call in enumerate(provider_tool_calls, start=1)
     ]
-    terminal_tools = [tool for tool in tool_names if tool in TERMINAL_ACTIONS]
+    terminal_tools = [tool for tool in tool_names if is_terminal_action_tool(tool)]
     if len(terminal_tools) > 1:
         raise MultipleTerminalActionsError(terminal_tools)
 

--- a/brain/db/schema.py
+++ b/brain/db/schema.py
@@ -77,7 +77,10 @@ CREATE TABLE IF NOT EXISTS tool_call_sent (
     provider_output_tokens INTEGER,
     provider_cached_input_tokens INTEGER,
     provider_cache_creation_input_tokens INTEGER,
-    provider_cache_read_input_tokens INTEGER
+    provider_cache_read_input_tokens INTEGER,
+    action_nonce TEXT,
+    state_version INTEGER,
+    session_epoch INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS tool_call_received (
@@ -87,6 +90,10 @@ CREATE TABLE IF NOT EXISTS tool_call_received (
     tool TEXT NOT NULL,
     result_status TEXT NOT NULL,
     latency_ms INTEGER NOT NULL,
+    action_nonce TEXT,
+    state_version INTEGER,
+    session_epoch INTEGER,
+    acceptance_status TEXT,
     error_class TEXT,
     retry_class TEXT,
     retry_attempt INTEGER NOT NULL DEFAULT 0
@@ -148,16 +155,35 @@ DECISION_RESPONSE_COLUMN_MIGRATIONS = {
     ),
 }
 
+TOOL_CALL_SENT_COLUMN_MIGRATIONS = {
+    "action_nonce": "ALTER TABLE tool_call_sent ADD COLUMN action_nonce TEXT",
+    "state_version": "ALTER TABLE tool_call_sent ADD COLUMN state_version INTEGER",
+    "session_epoch": "ALTER TABLE tool_call_sent ADD COLUMN session_epoch INTEGER",
+}
+
+TOOL_CALL_RECEIVED_COLUMN_MIGRATIONS = {
+    "action_nonce": "ALTER TABLE tool_call_received ADD COLUMN action_nonce TEXT",
+    "state_version": "ALTER TABLE tool_call_received ADD COLUMN state_version INTEGER",
+    "session_epoch": "ALTER TABLE tool_call_received ADD COLUMN session_epoch INTEGER",
+    "acceptance_status": "ALTER TABLE tool_call_received ADD COLUMN acceptance_status TEXT",
+}
+
 
 async def create_all(conn: aiosqlite.Connection) -> None:
     await conn.executescript(DDL)
-    await _migrate_decision_response(conn)
+    await _migrate_table(conn, "decision_response", DECISION_RESPONSE_COLUMN_MIGRATIONS)
+    await _migrate_table(conn, "tool_call_sent", TOOL_CALL_SENT_COLUMN_MIGRATIONS)
+    await _migrate_table(conn, "tool_call_received", TOOL_CALL_RECEIVED_COLUMN_MIGRATIONS)
 
 
-async def _migrate_decision_response(conn: aiosqlite.Connection) -> None:
-    cursor = await conn.execute("PRAGMA table_info(decision_response)")
+async def _migrate_table(
+    conn: aiosqlite.Connection,
+    table_name: str,
+    migrations: dict[str, str],
+) -> None:
+    cursor = await conn.execute(f"PRAGMA table_info({table_name})")
     rows = await cursor.fetchall()
     existing_columns = {str(row[1]) for row in rows}
-    for column_name, statement in DECISION_RESPONSE_COLUMN_MIGRATIONS.items():
+    for column_name, statement in migrations.items():
         if column_name not in existing_columns:
             await conn.execute(statement)

--- a/brain/db/writer.py
+++ b/brain/db/writer.py
@@ -149,6 +149,9 @@ class TelemetryWriter:
         call_id: str,
         tool: str,
         provider: ProviderTelemetry | None = None,
+        action_nonce: str | None = None,
+        state_version: int | None = None,
+        session_epoch: int | None = None,
     ) -> None:
         conn = self._require_conn()
         provider = provider or ProviderTelemetry()
@@ -159,9 +162,10 @@ class TelemetryWriter:
                 provider_item_id, provider_input_tokens, provider_output_tokens,
                 provider_cached_input_tokens,
                 provider_cache_creation_input_tokens,
-                provider_cache_read_input_tokens
+                provider_cache_read_input_tokens, action_nonce, state_version,
+                session_epoch
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 call_id,
@@ -174,6 +178,9 @@ class TelemetryWriter:
                 provider.provider_cached_input_tokens,
                 provider.provider_cache_creation_input_tokens,
                 provider.provider_cache_read_input_tokens,
+                action_nonce,
+                state_version,
+                session_epoch,
             ),
         )
         await conn.commit()
@@ -186,22 +193,31 @@ class TelemetryWriter:
         result_status: str,
         latency_ms: int,
         classification: ErrorRetryTelemetry | None = None,
+        action_nonce: str | None = None,
+        state_version: int | None = None,
+        session_epoch: int | None = None,
+        acceptance_status: str | None = None,
     ) -> None:
         conn = self._require_conn()
         classification = classification or ErrorRetryTelemetry()
         await conn.execute(
             """
             INSERT INTO tool_call_received (
-                call_id, tool, result_status, latency_ms, error_class,
+                call_id, tool, result_status, latency_ms, action_nonce,
+                state_version, session_epoch, acceptance_status, error_class,
                 retry_class, retry_attempt
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 call_id,
                 tool,
                 result_status,
                 latency_ms,
+                action_nonce,
+                state_version,
+                session_epoch,
+                acceptance_status,
                 classification.error_class,
                 classification.retry_class,
                 classification.retry_attempt,

--- a/brain/protocol.py
+++ b/brain/protocol.py
@@ -14,6 +14,12 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
 type JsonObject = dict[str, JsonValue]
 
+TERMINAL_ACTION_TOOLS = frozenset({"execute", "navigate_to", "choose"})
+
+
+def is_terminal_action_tool(tool: str) -> bool:
+    return tool in TERMINAL_ACTION_TOOLS
+
 
 class ToolResultStatus(StrEnum):
     OK = "ok"
@@ -28,6 +34,16 @@ class ToolResultMissingErrorCodeError(ValueError):
 class ToolResultMissingErrorMessageError(ValueError):
     def __init__(self) -> None:
         super().__init__("error status requires result.error_message")
+
+
+class TerminalToolCallMissingActionNonceError(ValueError):
+    def __init__(self) -> None:
+        super().__init__("terminal tool_call requires action_nonce")
+
+
+class TerminalToolCallMissingStateVersionError(ValueError):
+    def __init__(self) -> None:
+        super().__init__("terminal tool_call requires state_version")
 
 
 class ProviderMetadata(BaseModel):
@@ -67,7 +83,19 @@ class ToolCallMessage(BaseModel):
     args: JsonObject
     message_id: str
     session_epoch: int
+    action_nonce: str | None = None
+    state_version: int | None = None
     metadata: ProviderMetadata | None = None
+
+    @model_validator(mode="after")
+    def require_terminal_idempotency_fields(self) -> Self:
+        if not is_terminal_action_tool(self.tool):
+            return self
+        if self.action_nonce is None:
+            raise TerminalToolCallMissingActionNonceError
+        if self.state_version is None:
+            raise TerminalToolCallMissingStateVersionError
+        return self
 
 
 class ToolResultMessage(BaseModel):
@@ -80,6 +108,7 @@ class ToolResultMessage(BaseModel):
     message_id: str
     in_reply_to: str
     session_epoch: int
+    action_nonce: str | None = None
     metadata: ProviderMetadata | None = None
 
 

--- a/brain/protocol.py
+++ b/brain/protocol.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
 type JsonObject = dict[str, JsonValue]
 
-TERMINAL_ACTION_TOOLS = frozenset({"execute", "navigate_to", "choose"})
+TERMINAL_ACTION_TOOLS: frozenset[str] = frozenset({"execute", "navigate_to", "choose"})
 
 
 def is_terminal_action_tool(tool: str) -> bool:

--- a/docs/adr/0017-phase-1-pr-3-terminal-action-idempotency.md
+++ b/docs/adr/0017-phase-1-pr-3-terminal-action-idempotency.md
@@ -1,0 +1,113 @@
+# ADR 0017: Phase 1 PR-3 terminal action idempotency
+
+Status: Accepted (2026-05-21)
+
+Amend marker: Amend v5.9
+
+## Context
+
+ADR 0015 locked PR-2.1 as the provider-neutral protocol-core slice and
+explicitly deferred terminal-action idempotency to PR-3. ADR 0016 then
+clarified `call_id` as the canonical tool invocation identity for the
+`tool_call` / `tool_result` envelope.
+
+Frozen v5.9 still requires terminal action safety before provider-backed
+tool execution becomes load-bearing. Terminal actions such as `execute`,
+`navigate_to`, and `choose` can mutate the game state, so duplicate
+transport delivery, stale provider responses, or cross-session replay
+must not execute a second game action.
+
+The PR-3 plan records the implementation details in
+`docs/superpowers/plans/2026-04-29-phase-1-pr-3-terminal-action-idempotency.md`.
+Because plan files are governed artifacts, this ADR records the decision
+that authorizes the PR-3 plan and implementation scope without editing
+`docs/architecture-v5.md`.
+
+## Decision
+
+Phase 1 PR-3 implements terminal action idempotency for exactly these
+terminal tools:
+
+- `execute`
+- `navigate_to`
+- `choose`
+
+Terminal `tool_call` messages carry:
+
+- `action_nonce`: a Python Brain generated per-action idempotency key.
+- `state_version`: the decision-turn state version the action applies to.
+- `snapshot_hash`: the SHA-256 hash of the exact decision-input JSON bytes,
+  carried inside terminal tool arguments.
+
+C# computes the expected `state_version` and `snapshot_hash` from the
+outbound decision input before it accepts a terminal action. `ToolRouter`
+rejects terminal actions that are missing idempotency fields, use a stale
+`session_epoch`, target a stale state version, present a mismatched
+snapshot hash, or duplicate a completed terminal state version.
+
+C# caches terminal results by transport `message_id` and by
+`session_epoch:action_nonce`. Replayed duplicate requests return the
+cached result instead of executing another terminal action.
+
+Non-terminal tools keep the PR-2.1 envelope shape and do not require
+`action_nonce`, `state_version`, or `snapshot_hash`.
+
+## Alternatives Considered
+
+- **Use only `message_id` for duplicate suppression.** Rejected because
+  provider retries can arrive as a new transport message for the same
+  logical terminal action. `action_nonce` is the logical idempotency key.
+- **Use only `call_id` for duplicate suppression.** Rejected because
+  `call_id` identifies the provider-neutral tool invocation, not the
+  terminal-action execution attempt across reconnects and transport
+  retries.
+- **Apply idempotency fields to every tool.** Rejected because PR-3 only
+  needs mutation safety for terminal actions. Read-only and operational
+  tools should not inherit unnecessary required fields.
+- **Allow parallel terminal actions now.** Rejected for turn coherence.
+  Terminal action dispatch remains sequential until a future ADR defines
+  ordering and conflict semantics.
+
+## Consequences
+
+Easier:
+
+- Duplicate terminal delivery is safe across transport message replay and
+  provider retry surfaces.
+- The Python Brain can detect mismatched terminal results by `action_nonce`.
+- Telemetry can record terminal idempotency fields and acceptance status
+  for later replay analysis.
+
+Harder:
+
+- Terminal action probes must provide a current `snapshot_hash` when they
+  exercise `execute`, `navigate_to`, or `choose`.
+- A dedicated adversarial in-game probe is still needed if runtime evidence
+  for each rejection branch is required; the PR-3 E2E run covers the
+  happy path, while automated tests cover duplicate and stale branches.
+
+Re-open triggers:
+
+- If provider adapters need parallel terminal action emission before
+  Phase 2a Gate 1.
+- If `snapshot_hash` over exact JSON bytes proves unstable across the
+  C# and Python boundary in a supported runtime.
+- If terminal tools are added or reclassified beyond `execute`,
+  `navigate_to`, and `choose`.
+
+## Related Artifacts
+
+- `docs/superpowers/plans/2026-04-29-phase-1-pr-3-terminal-action-idempotency.md`
+  - PR-3 implementation plan.
+- `docs/memo/phase-1-pr-3-e2e-acceptance-2026-04-30.md` - PR-3
+  happy-path E2E acceptance memo.
+- `docs/adr/0015-phase-1-pr-2-readiness-scope.md` - PR-2.1 scope and
+  PR-3 idempotency deferral.
+- `docs/adr/0016-pr-2-1-tool-envelope-call-id.md` - tool envelope
+  invocation identity.
+- `docs/architecture-v5.md:2634-2677` - terminal action idempotency and
+  stale-response requirements.
+
+## Supersedes
+
+None.

--- a/docs/adr/decision-log.md
+++ b/docs/adr/decision-log.md
@@ -46,3 +46,4 @@ individual decision artifact under `docs/adr/decisions/`.
 - 2026-04-29T03:03:57Z | adr_required=true | Add Phase 1 PR-2 readiness scope | [details](decisions/2026-04-29-add-phase-1-pr-2-readiness-scope.md)
 - 2026-04-29T05:16:27Z | adr_required=true | Add ADR 0016 for PR-2.1 tool envelope call_id identity | [details](decisions/2026-04-29-add-adr-0016-for-pr-2-1-tool-envelope-call-id-identity.md)
 - 2026-04-29T05:28:25Z | adr_required=true | Cover Phase 1 PR-2 branch ADR changes | [details](decisions/2026-04-29-cover-phase-1-pr-2-branch-adr-changes.md)
+- 2026-05-21T12:34:57Z | adr_required=true | Add ADR 0017 for Phase 1 PR-3 terminal action idempotency | [details](decisions/2026-05-21-add-adr-0017-for-phase-1-pr-3-terminal-action-idempotency.md)

--- a/docs/adr/decisions/2026-05-21-add-adr-0017-for-phase-1-pr-3-terminal-action-idempotency.md
+++ b/docs/adr/decisions/2026-05-21-add-adr-0017-for-phase-1-pr-3-terminal-action-idempotency.md
@@ -5,10 +5,11 @@ change: Add ADR 0017 for Phase 1 PR-3 terminal action idempotency
 adr_required: true
 rationale: PR-3 adds a governed terminal-action idempotency plan and implementation for frozen Phase 1 scope; the ADR records the plan authority and mutation-safety contract.
 files:
-  - brain/app.py
-  - brain/protocol.py
-  - docs/adr/0017-phase-1-pr-3-terminal-action-idempotency.md
-  - mod/LLMOfQud/ToolRouter.cs
-  - tests/test_mod_static_contracts.py
+  - brain/app.py:347-389
+  - brain/protocol.py:17-21
+  - docs/adr/0017-phase-1-pr-3-terminal-action-idempotency.md:1-113
+  - mod/LLMOfQud/ToolRouter.cs:51-112
+  - mod/LLMOfQud/ToolRouter.cs:1088-1093
+  - tests/test_mod_static_contracts.py:471-500
 adr_paths:
-  - docs/adr/0017-phase-1-pr-3-terminal-action-idempotency.md
+  - docs/adr/0017-phase-1-pr-3-terminal-action-idempotency.md:1

--- a/docs/adr/decisions/2026-05-21-add-adr-0017-for-phase-1-pr-3-terminal-action-idempotency.md
+++ b/docs/adr/decisions/2026-05-21-add-adr-0017-for-phase-1-pr-3-terminal-action-idempotency.md
@@ -1,0 +1,14 @@
+# ADR Decision Record
+
+timestamp: 2026-05-21T12:34:57Z
+change: Add ADR 0017 for Phase 1 PR-3 terminal action idempotency
+adr_required: true
+rationale: PR-3 adds a governed terminal-action idempotency plan and implementation for frozen Phase 1 scope; the ADR records the plan authority and mutation-safety contract.
+files:
+  - brain/app.py
+  - brain/protocol.py
+  - docs/adr/0017-phase-1-pr-3-terminal-action-idempotency.md
+  - mod/LLMOfQud/ToolRouter.cs
+  - tests/test_mod_static_contracts.py
+adr_paths:
+  - docs/adr/0017-phase-1-pr-3-terminal-action-idempotency.md

--- a/docs/memo/phase-1-pr-3-e2e-acceptance-2026-04-30.md
+++ b/docs/memo/phase-1-pr-3-e2e-acceptance-2026-04-30.md
@@ -1,0 +1,91 @@
+# Phase 1 PR-3 E2E Acceptance Memo
+
+Date: 2026-04-30
+Branch: `codex/phase-1-pr-3-idempotency`
+Verdict: PASS for terminal tool-call happy path
+
+## Scope
+
+This run validates that the Phase 1 PR-3 branch Roslyn-compiles in Caves of
+Qud, loads the `LLMOfQud` mod, and completes an in-game WebSocket round trip
+through the Python Brain `tool_call_probe:execute` phase.
+
+It does not inject adversarial duplicate or stale terminal tool calls in-game.
+Those paths remain covered by Python tests and C# static contract tests.
+
+## Commands / Checks
+
+- Started the Python Brain probe server:
+
+  ```bash
+  uv run python -m brain.app --phase tool_call_probe:execute --port 4040
+  ```
+
+- Confirmed Caves of Qud mod compile/load from:
+
+  ```text
+  ~/Library/Application Support/Freehold Games/CavesOfQud/build_log.txt
+  ```
+
+- Confirmed runtime round-trip counts from:
+
+  ```text
+  ~/Library/Logs/Freehold Games/CavesOfQud/Player.log
+  ```
+
+## Build Evidence
+
+The build log for the accepted run contains:
+
+```text
+[2026-04-30T23:15:50] === LLM OF QUD ===
+[2026-04-30T23:15:50] Compiling 8 files...
+[2026-04-30T23:15:51] Success :)
+[2026-04-30T23:15:56] [LLMOfQud] loaded v0.0.1 at 2026-04-30T14:15:56.8061380Z
+```
+
+## E2E Evidence
+
+| Signal | Count |
+|---|---:|
+| C# `[LLMOfQud][decision_request] queued` | 330 |
+| C# `[LLMOfQud][decision_response] received` | 330 |
+| C# `[LLMOfQud][decision]` | 330 |
+| C# `[LLMOfQud][disconnect_pause]` | 0 |
+| Python server `phase=tool_call_probe:execute` decision requests | 330 |
+| Python server `decision_response` | 330 |
+| LLMOfQud-specific runtime error markers | 0 |
+
+The first attempted game launch in this session ran without a Brain server
+listening on `localhost:4040`, producing 52 `disconnect_pause` lines and no
+decision responses. That run is excluded from the accepted evidence window.
+
+The accepted run started after the Brain server was listening on
+`localhost:4040`; it completed 330 matched request/response/decision cycles.
+
+## Notes
+
+- The Python server logged a `ConnectionClosedError` after turn 330 when the
+  game process exited without a close frame. This is shutdown noise and did not
+  occur until after the accepted evidence window.
+- The runtime log contains 9 `[cmd]` lines with `result:false` and
+  `fallback:"pass_turn"`. These are command-issuance fallbacks for blocked or
+  failed in-game movement, not WebSocket transport failures and not terminal
+  tool-call idempotency failures.
+
+## Limitations
+
+This happy-path E2E run exercises terminal tool-call dispatch through
+`tool_call_probe:execute`, including live Roslyn compilation and in-game
+WebSocket request/response flow. It does not prove the adversarial idempotency
+branches in-game:
+
+- duplicate `message_id`
+- duplicate `action_nonce`
+- stale `state_version`
+- stale `session_epoch`
+- mismatched `snapshot_hash`
+
+Those branches are covered by automated tests in this branch. A future in-game
+probe phase can deliberately inject those malformed or duplicate tool calls if
+runtime evidence for each rejection branch is required.

--- a/docs/superpowers/plans/2026-04-29-phase-1-pr-3-terminal-action-idempotency.md
+++ b/docs/superpowers/plans/2026-04-29-phase-1-pr-3-terminal-action-idempotency.md
@@ -1,0 +1,1063 @@
+# Phase 1 PR-3 Terminal Action Idempotency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Phase 1-G terminal-action idempotency so duplicate or stale terminal tool calls cannot double-execute before Phase 2a.
+
+**Architecture:** PR-3 extends the PR-2 provider-neutral `tool_call` / `tool_result` envelope without changing provider-specific adapter semantics. Python validates and emits terminal-action idempotency fields; C# parses them, rejects stale terminal actions, and returns cached terminal `tool_result` envelopes for duplicate `(session_epoch, action_nonce)` calls. Non-terminal tools keep the PR-2 shape and are not deduplicated in this slice.
+
+**Tech Stack:** Python 3.13, Pydantic v2, pytest, websockets 16.0, SQLite via aiosqlite, Roslyn-compatible C# source under `mod/LLMOfQud/`.
+
+---
+
+## Source of Truth
+
+- `docs/architecture-v5.md:2411-2424` defines the normalized `tool_call` / `tool_result` envelope and says terminal actions include top-level `action_nonce` and `state_version`.
+- `docs/architecture-v5.md:2486-2516` shows the terminal action example and the terminal result output contract.
+- `docs/architecture-v5.md:2863-2877` defines Phase 1-G: cache by `(session_epoch, action_nonce)`, reject stale `state_version`, reject stale `session_epoch`, minimum terminal-action `message_id` dedup, duplicate turn suppression, and defer non-terminal deduplication to Phase 2b.
+- `docs/architecture-v5.md:2905-2909` makes Phase 1-G a hard prerequisite before Phase 2a Gate 1.
+- `docs/adr/0011-phase-1-pr-1-scope.md:85-89` says PR-3 requires no new ADR because v5.9 carries the contract.
+- `docs/adr/0015-phase-1-pr-2-readiness-scope.md:94-99` confirms PR-2 intentionally deferred this behavior.
+
+## File Structure
+
+- Modify `brain/protocol.py`: add optional top-level `action_nonce` and `state_version` to `ToolCallMessage`, add optional top-level `action_nonce` to `ToolResultMessage`, plus an `is_terminal_action_tool()` helper and after-validation requiring both call-side fields only for `execute`, `navigate_to`, and `choose`.
+- Modify `brain/app.py`: make probe terminal tool calls include deterministic `action_nonce`, `state_version`, and `args.snapshot_hash` derived from the exact decision-input JSON received by the probe server.
+- Modify `brain/db/schema.py`: add nullable terminal-idempotency telemetry columns to `tool_call_sent` and `tool_call_received`, plus migrations for existing PR-2 DBs.
+- Modify `brain/db/writer.py`: accept and persist terminal idempotency telemetry without making non-terminal writes pass extra arguments.
+- Modify `mod/LLMOfQud/ToolRouter.cs`: parse terminal idempotency fields, enforce session/state guards, cache terminal results keyed by `(session_epoch, action_nonce)`, and return cached results on duplicate calls.
+- Modify `mod/LLMOfQud/BrainClient.cs`: update the long-lived `ToolRouter` with the current `decision_input.v1.turn` before processing tool calls. PR-3 uses the current turn as the Phase 1 state-version approximation until `turn_start.state_version` exists on the live wire.
+- Modify tests: `tests/test_protocol_messages.py`, `tests/test_brain_app.py`, `tests/test_brain_db.py`, and `tests/test_mod_static_contracts.py`.
+
+## Locked Semantics
+
+- Terminal tools are exactly `execute`, `navigate_to`, and `choose`; `cancel_or_back` remains non-terminal in PR-3.
+- A duplicate terminal action with the same `(session_epoch, action_nonce)` returns the previously cached `tool_result` envelope. It does not call the handler again.
+- A duplicate terminal `message_id` returns the previously cached `tool_result` envelope for that message. This is the minimum terminal-action `message_id` dedup scope required by v5.9; non-terminal `message_id` dedup remains Phase 2b.
+- Duplicate cached results preserve the original `result.output`; `message_id` and `in_reply_to` may be regenerated to match the duplicate request's transport edge.
+- A second terminal action for an already-completed state version with a different nonce is rejected with `acceptance_status == "duplicate"`.
+- A stale `state_version` terminal action returns `result.status == "ok"` with `result.output.acceptance_status == "stale"` and `accepted == false`.
+- A terminal action whose `args.snapshot_hash` does not match the current decision-input snapshot hash returns `result.status == "ok"` with `result.output.acceptance_status == "stale"` and `accepted == false`.
+- Terminal `tool_result` envelopes echo the terminal `action_nonce` at top level, matching `docs/architecture-v5.md:2517`.
+- A stale `session_epoch` terminal action returns `result.status == "ok"` with `result.output.acceptance_status == "stale_epoch"` and `accepted == false`.
+- Non-terminal tool calls may include no `action_nonce` / `state_version`; PR-3 does not add non-terminal deduplication.
+- In Phase 1 PR-3 live transport, `state_version` maps to the current `decision_input.v1.turn`, and `snapshot_hash` maps to a deterministic hash of the exact `decision_input.v1` JSON. Frozen v5.9's `turn_start.state_version` / `turn_start.snapshot_hash` remain the future richer sources once `turn_start` is introduced on the WebSocket wire.
+- No Phase 2a provider client, real game action execution, pathfinding, or LLM call is introduced.
+
+## Task 1: Python Protocol Fields
+
+**Files:**
+- Modify: `brain/protocol.py`
+- Test: `tests/test_protocol_messages.py`
+
+- [ ] **Step 1: Write failing protocol tests**
+
+Add these tests to `tests/test_protocol_messages.py`:
+
+```python
+def test_terminal_tool_call_requires_action_nonce_and_state_version() -> None:
+    base_message: JsonObject = {
+        "type": "tool_call",
+        "call_id": "turn-7-call-1",
+        "tool": "execute",
+        "args": {"candidate_id": "c1"},
+        "message_id": "msg-7-call-1",
+        "session_epoch": 3,
+    }
+
+    with pytest.raises(ValidationError, match="action_nonce"):
+        ToolCallMessage.model_validate(base_message)
+    with pytest.raises(ValidationError, match="state_version"):
+        ToolCallMessage.model_validate(base_message | {"action_nonce": "nonce-7"})
+
+    message = ToolCallMessage.model_validate(
+        base_message | {"action_nonce": "nonce-7", "state_version": 284},
+    )
+
+    assert message.action_nonce == "nonce-7"
+    assert message.state_version == 284
+
+
+def test_non_terminal_tool_call_does_not_require_terminal_idempotency_fields() -> None:
+    message = ToolCallMessage.model_validate(
+        {
+            "type": "tool_call",
+            "call_id": "turn-7-call-1",
+            "tool": "inspect_surroundings",
+            "args": {},
+            "message_id": "msg-7-call-1",
+            "session_epoch": 3,
+        },
+    )
+
+    assert message.action_nonce is None
+    assert message.state_version is None
+
+
+def test_terminal_tool_result_can_echo_action_nonce() -> None:
+    message = ToolResultMessage.model_validate(
+        {
+            "type": "tool_result",
+            "call_id": "turn-7-call-1",
+            "tool": "execute",
+            "result": {"status": "ok", "output": {"acceptance_status": "accepted"}},
+            "message_id": "msg-7-result-1",
+            "in_reply_to": "msg-7-call-1",
+            "session_epoch": 3,
+            "action_nonce": "nonce-7",
+        },
+    )
+
+    assert message.action_nonce == "nonce-7"
+```
+
+- [ ] **Step 2: Run protocol tests to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_protocol_messages.py -k 'terminal_tool_call_requires_action_nonce or non_terminal_tool_call or terminal_tool_result_can_echo_action_nonce' -q
+```
+
+Expected: FAIL because `ToolCallMessage` has no `action_nonce` / `state_version` fields and `ToolResultMessage` has no `action_nonce` field.
+
+- [ ] **Step 3: Implement minimal protocol validation**
+
+In `brain/protocol.py`, add:
+
+```python
+TERMINAL_ACTION_TOOLS = frozenset({"execute", "navigate_to", "choose"})
+
+
+def is_terminal_action_tool(tool: str) -> bool:
+    return tool in TERMINAL_ACTION_TOOLS
+```
+
+Then extend `ToolCallMessage`:
+
+```python
+class ToolCallMessage(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    message_type: Literal["tool_call"] = Field(default="tool_call", alias="type")
+    call_id: str
+    tool: str
+    args: JsonObject
+    message_id: str
+    session_epoch: int
+    action_nonce: str | None = None
+    state_version: int | None = None
+    metadata: ProviderMetadata | None = None
+
+    @model_validator(mode="after")
+    def require_terminal_idempotency_fields(self) -> Self:
+        if not is_terminal_action_tool(self.tool):
+            return self
+        if self.action_nonce is None:
+            raise ValueError("terminal tool_call requires action_nonce")
+        if self.state_version is None:
+            raise ValueError("terminal tool_call requires state_version")
+        return self
+```
+
+Then extend `ToolResultMessage`:
+
+```python
+class ToolResultMessage(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    message_type: Literal["tool_result"] = Field(default="tool_result", alias="type")
+    call_id: str
+    tool: str
+    result: ToolResultPayload
+    message_id: str
+    in_reply_to: str
+    session_epoch: int
+    action_nonce: str | None = None
+    metadata: ProviderMetadata | None = None
+```
+
+- [ ] **Step 4: Run protocol tests to verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_protocol_messages.py -k 'terminal_tool_call_requires_action_nonce or non_terminal_tool_call or terminal_tool_result_can_echo_action_nonce' -q
+```
+
+Expected: PASS.
+
+## Task 2: Python Probe Emission and Round Trip
+
+**Files:**
+- Modify: `brain/app.py`
+- Test: `tests/test_brain_app.py`
+
+- [ ] **Step 1: Write failing terminal emission tests**
+
+Add these tests to `tests/test_brain_app.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_terminal_tool_call_probe_includes_action_nonce_and_state_version() -> None:
+    tool_call, response = await run_fake_csharp_tool_roundtrip(
+        phase="tool_call_probe:execute",
+    )
+
+    assert tool_call["tool"] == "execute"
+    assert tool_call["action_nonce"] == "turn-7-execute-nonce"
+    assert tool_call["state_version"] == 7
+    assert isinstance(tool_call["args"]["snapshot_hash"], str)
+    assert response["schema"] == "decision.v1"
+
+
+def test_terminal_tool_call_batch_uses_deterministic_nonce_and_state_version() -> None:
+    (message,) = build_tool_call_messages(
+        [{"tool": "execute", "args": {"candidate_id": "c1"}, "call_id": "call-1"}],
+        turn=7,
+        session_epoch=3,
+        snapshot_hash="snapshot-7",
+    )
+
+    assert message.action_nonce == "turn-7-execute-nonce"
+    assert message.state_version == 7
+    assert message.args["snapshot_hash"] == "snapshot-7"
+```
+
+- [ ] **Step 2: Run app tests to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_brain_app.py -k 'terminal_tool_call_probe_includes_action_nonce or terminal_tool_call_batch' -q
+```
+
+Expected: FAIL because `build_tool_call_messages()` does not set terminal idempotency fields.
+
+- [ ] **Step 3: Implement deterministic probe fields**
+
+In `brain/app.py`, import `hashlib` and `is_terminal_action_tool` from `brain.protocol`. Add a snapshot hash to `DecisionRequest`, computed from the exact inbound JSON:
+
+```python
+class DecisionRequest(BaseModel):
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    turn: int
+    request_schema: str = Field(alias="schema")
+    summary: DecisionInputSummary
+    snapshot_hash: str
+```
+
+In `parse_decision_input()`, pass:
+
+```python
+snapshot_hash=decision_input_snapshot_hash(message),
+```
+
+Define the helper with SHA-256 so the C# transport can compute the same value from the exact request JSON it sent:
+
+```python
+def decision_input_snapshot_hash(message: str | bytes) -> str:
+    data = message.encode("utf-8") if isinstance(message, str) else message
+    return hashlib.sha256(data).hexdigest()
+```
+
+Change the `build_tool_call_messages()` signature:
+
+```python
+def build_tool_call_messages(
+    provider_tool_calls: list[dict[str, object]],
+    *,
+    turn: int,
+    session_epoch: int,
+    snapshot_hash: str | None = None,
+) -> tuple[ToolCallMessage, ...]:
+```
+
+Then change the `ToolCallMessage(...)` construction:
+
+```python
+        terminal_action = is_terminal_action_tool(tool)
+        args = require_protocol_json_object(
+            call.get("args", {}),
+            f"provider_tool_calls[{index}].args",
+        )
+        if terminal_action and snapshot_hash is not None:
+            args = args | {"snapshot_hash": snapshot_hash}
+        messages.append(
+            ToolCallMessage(
+                call_id=call_id,
+                tool=tool,
+                args=args,
+                message_id=f"msg-{turn}-tool-call-{index}",
+                session_epoch=session_epoch,
+                action_nonce=(
+                    f"turn-{turn}-{tool}-nonce" if terminal_action else None
+                ),
+                state_version=turn if terminal_action else None,
+            ),
+        )
+```
+
+In `emit_probe_tool_call()`, pass the request hash:
+
+```python
+    (tool_call,) = build_tool_call_messages(
+        [{"tool": tool, "args": args}],
+        turn=request.turn,
+        session_epoch=PROBE_SESSION_EPOCH,
+        snapshot_hash=request.snapshot_hash,
+    )
+```
+
+- [ ] **Step 4: Run app tests to verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_brain_app.py -k 'terminal_tool_call_probe_includes_action_nonce or terminal_tool_call_batch' -q
+```
+
+Expected: PASS.
+
+## Task 3: C# Envelope Parsing and Static Contract
+
+**Files:**
+- Modify: `mod/LLMOfQud/ToolRouter.cs`
+- Test: `tests/test_mod_static_contracts.py`
+
+- [ ] **Step 1: Write failing static parsing tests**
+
+Add these tests to `tests/test_mod_static_contracts.py`:
+
+```python
+def test_tool_call_envelope_declares_terminal_idempotency_fields() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    parse_body = method_body(source, "public static ToolCallEnvelope ParseToolCallEnvelope")
+    build_body = method_body(source, "public static string BuildToolResultJson")
+
+    assert 'FieldActionNonce = "action_nonce"' in source
+    assert 'FieldStateVersion = "state_version"' in source
+    assert "ActionNonce = ReadOptionalString(json, ToolProtocolFields.FieldActionNonce)" in parse_body
+    assert "StateVersion = ReadNullableInt(json, ToolProtocolFields.FieldStateVersion)" in parse_body
+    assert "AppendJsonProperty(sb, ToolProtocolFields.FieldActionNonce, envelope.ActionNonce)" in build_body
+    assert "public string ActionNonce;" in source
+    assert "public int? StateVersion;" in source
+    assert "private static string ReadOptionalString" in source
+
+
+def test_toolrouter_parses_non_terminal_tool_call_without_idempotency_fields() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    parse_body = method_body(source, "public static ToolCallEnvelope ParseToolCallEnvelope")
+
+    assert "ActionNonce = ReadOptionalString(json, ToolProtocolFields.FieldActionNonce)" in parse_body
+    assert "StateVersion = ReadNullableInt(json, ToolProtocolFields.FieldStateVersion)" in parse_body
+    assert "JSON field missing: \" + name" in source
+
+
+def test_terminal_idempotency_cache_key_is_session_epoch_and_action_nonce() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+
+    assert "private readonly Dictionary<string, ToolResultEnvelope> _terminalActionCache" in source
+    assert "TerminalActionCacheKey(call.SessionEpoch, call.ActionNonce)" in source
+    assert "return call.SessionEpoch.ToString(CultureInfo.InvariantCulture) + \":\" + call.ActionNonce;" in source
+```
+
+- [ ] **Step 2: Run static tests to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_mod_static_contracts.py -k 'terminal_idempotency_fields or terminal_idempotency_cache_key' -q
+```
+
+Expected: FAIL because C# envelope fields and cache are absent.
+
+- [ ] **Step 3: Implement parsing fields and cache key only**
+
+In `mod/LLMOfQud/ToolRouter.cs`:
+
+```csharp
+private readonly Dictionary<string, ToolResultEnvelope> _terminalActionCache =
+    new Dictionary<string, ToolResultEnvelope>();
+```
+
+Add constants:
+
+```csharp
+public const string FieldActionNonce = "action_nonce";
+public const string FieldStateVersion = "state_version";
+```
+
+Extend `ParseToolCallEnvelope`:
+
+```csharp
+ActionNonce = ReadOptionalString(json, ToolProtocolFields.FieldActionNonce),
+StateVersion = ReadNullableInt(json, ToolProtocolFields.FieldStateVersion),
+```
+
+Extend `BuildToolResultJson()` after `session_epoch`, but only for terminal results that actually carry a nonce:
+
+```csharp
+if (envelope.ActionNonce != null)
+{
+    sb.Append(',');
+    AppendJsonProperty(sb, ToolProtocolFields.FieldActionNonce, envelope.ActionNonce);
+}
+```
+
+Add:
+
+```csharp
+private static string ReadOptionalString(string json, string name)
+{
+    try
+    {
+        return ReadStringOrNull(json, name);
+    }
+    catch (DisconnectedException ex)
+    {
+        if (ex.Message == "JSON field missing: " + name)
+        {
+            return null;
+        }
+        throw;
+    }
+}
+
+private static int? ReadNullableInt(string json, string name)
+{
+    try
+    {
+        return ReadInt(json, name);
+    }
+    catch (DisconnectedException ex)
+    {
+        if (ex.Message == "JSON field missing: " + name)
+        {
+            return null;
+        }
+        throw;
+    }
+}
+
+private static string TerminalActionCacheKey(int sessionEpoch, string actionNonce)
+{
+    return sessionEpoch.ToString(CultureInfo.InvariantCulture) + ":" + actionNonce;
+}
+```
+
+Extend `ToolCallEnvelope`:
+
+```csharp
+public string ActionNonce;
+public int? StateVersion;
+```
+
+Extend `ToolResultEnvelope`:
+
+```csharp
+public string ActionNonce;
+```
+
+- [ ] **Step 4: Run static tests to verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_mod_static_contracts.py -k 'terminal_idempotency_fields or terminal_idempotency_cache_key' -q
+```
+
+Expected: PASS.
+
+## Task 4: C# Stale and Duplicate Behavior
+
+**Files:**
+- Modify: `mod/LLMOfQud/ToolRouter.cs`
+- Modify: `mod/LLMOfQud/BrainClient.cs`
+- Test: `tests/test_mod_static_contracts.py`
+
+- [ ] **Step 1: Write failing stale/duplicate static tests**
+
+Add these tests to `tests/test_mod_static_contracts.py`:
+
+```python
+def test_toolrouter_rejects_stale_terminal_actions_before_dispatch() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    dispatch_body = method_body(source, "public ToolResultEnvelope Dispatch")
+
+    assert "_sessionEpochProvider" in source
+    assert 'TerminalActionOutput.Stale("stale_epoch")' in dispatch_body
+    assert 'TerminalActionOutput.Stale("stale")' in dispatch_body
+    assert "call.SessionEpoch != _sessionEpochProvider()" in dispatch_body
+    assert "call.StateVersion.Value != _expectedStateVersion" in dispatch_body
+
+
+def test_toolrouter_returns_cached_duplicate_terminal_action_result() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    dispatch_body = method_body(source, "public ToolResultEnvelope Dispatch")
+
+    assert "_terminalActionCache.TryGetValue(cacheKey, out cached)" in dispatch_body
+    assert "_terminalMessageCache.TryGetValue(call.MessageId, out cached)" in dispatch_body
+    assert "CloneForDuplicateRequest(cached, call)" in dispatch_body
+    assert "_terminalActionCache[cacheKey] = CloneForCache(result)" in dispatch_body
+    assert "_terminalMessageCache[call.MessageId] = CloneForCache(result)" in dispatch_body
+    assert "TerminalActionOutput.Accepted(call.Tool)" in dispatch_body
+
+
+def test_toolrouter_suppresses_duplicate_terminal_turn_and_checks_snapshot_hash() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    dispatch_body = method_body(source, "public ToolResultEnvelope Dispatch")
+
+    assert "_completedTerminalStateVersions.Contains(call.StateVersion.Value)" in dispatch_body
+    assert 'TerminalActionOutput.Stale("duplicate")' in dispatch_body
+    assert 'ReadStringArgOrNull(call.Args, "snapshot_hash")' in dispatch_body
+    assert "!= _expectedSnapshotHash" in dispatch_body
+    assert "_completedTerminalStateVersions.Add(call.StateVersion.Value)" in dispatch_body
+
+
+def test_brainclient_sets_expected_state_version_and_snapshot_hash_before_receive() -> None:
+    source = (ROOT / "mod/LLMOfQud/BrainClient.cs").read_text()
+    run_loop_body = method_body(source, "private void RunLoop()")
+
+    assert "toolRouter.SetExpectedTurnContext(" in run_loop_body
+    assert "ParseDecisionInputTurn(pending.RequestJson)" in run_loop_body
+    assert "ComputeDecisionInputSnapshotHash(pending.RequestJson)" in run_loop_body
+
+
+def test_tool_result_message_id_factory_is_public_for_cached_terminal_results() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+
+    assert "public static string CreateMessageId(" in source
+    assert "private static string CreateMessageId(" not in source
+```
+
+- [ ] **Step 2: Run static tests to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_mod_static_contracts.py -q
+```
+
+Expected: FAIL because stale/duplicate behavior, BrainClient context wiring, and public message-id factory behavior are absent.
+
+- [ ] **Step 3: Implement minimal stale/duplicate behavior**
+
+Add state fields and constructor overloads to `ToolRouter`:
+
+```csharp
+private readonly Func<int> _sessionEpochProvider;
+private readonly Dictionary<string, ToolResultEnvelope> _terminalMessageCache =
+    new Dictionary<string, ToolResultEnvelope>();
+private readonly HashSet<int> _completedTerminalStateVersions = new HashSet<int>();
+private int _expectedStateVersion;
+private string _expectedSnapshotHash;
+
+public ToolRouter() : this(() => 1)
+{
+}
+
+public ToolRouter(Func<int> sessionEpochProvider)
+{
+    _sessionEpochProvider = sessionEpochProvider ?? (() => 1);
+    _expectedStateVersion = 0;
+    _expectedSnapshotHash = null;
+}
+
+public void SetExpectedTurnContext(int stateVersion, string snapshotHash)
+{
+    _expectedStateVersion = stateVersion;
+    _expectedSnapshotHash = snapshotHash;
+}
+```
+
+At the start of `Dispatch`, after the null-call guard:
+
+```csharp
+if (IsTerminalAction(call.Tool))
+{
+    if (call.ActionNonce == null || !call.StateVersion.HasValue)
+    {
+        return TerminalActionResult(
+            call,
+            TerminalActionOutput.Stale("stale"),
+            "terminal action requires action_nonce and state_version");
+    }
+
+    if (call.SessionEpoch != _sessionEpochProvider())
+    {
+        return TerminalActionResult(
+            call,
+            TerminalActionOutput.Stale("stale_epoch"),
+            "terminal action belongs to a stale session epoch");
+    }
+
+    ToolResultEnvelope cached;
+    if (_terminalMessageCache.TryGetValue(call.MessageId, out cached))
+    {
+        return CloneForDuplicateRequest(cached, call);
+    }
+
+    string cacheKey = TerminalActionCacheKey(call.SessionEpoch, call.ActionNonce);
+    if (_terminalActionCache.TryGetValue(cacheKey, out cached))
+    {
+        return CloneForDuplicateRequest(cached, call);
+    }
+
+    if (call.StateVersion.Value != _expectedStateVersion)
+    {
+        return TerminalActionResult(
+            call,
+            TerminalActionOutput.Stale("stale"),
+            "terminal action belongs to a stale state version");
+    }
+
+    if (ReadStringArgOrNull(call.Args, "snapshot_hash") != _expectedSnapshotHash)
+    {
+        return TerminalActionResult(
+            call,
+            TerminalActionOutput.Stale("stale"),
+            "terminal action snapshot_hash does not match current state");
+    }
+
+    if (_completedTerminalStateVersions.Contains(call.StateVersion.Value))
+    {
+        return TerminalActionResult(
+            call,
+            TerminalActionOutput.Stale("duplicate"),
+            "terminal action already completed for this state version");
+    }
+
+    ToolResultEnvelope result = TerminalActionResult(
+        call,
+        TerminalActionOutput.Accepted(call.Tool),
+        null);
+    _terminalActionCache[cacheKey] = CloneForCache(result);
+    _terminalMessageCache[call.MessageId] = CloneForCache(result);
+    _completedTerminalStateVersions.Add(call.StateVersion.Value);
+    return result;
+}
+```
+
+Add small helpers in `ToolRouter.cs`:
+
+```csharp
+private static ToolResultEnvelope TerminalActionResult(
+    ToolCallEnvelope call,
+    Dictionary<string, object> output,
+    string errorMessage)
+{
+    return new ToolResultEnvelope
+    {
+        CallId = call.CallId,
+        Tool = call.Tool,
+        Result = ToolResult.Ok(output),
+        MessageId = ToolResultEnvelope.CreateMessageId(call.CallId, call.Tool, call.SessionEpoch),
+        InReplyTo = call.MessageId,
+        SessionEpoch = call.SessionEpoch,
+        ActionNonce = call.ActionNonce,
+    };
+}
+
+private static ToolResultEnvelope CloneForDuplicateRequest(
+    ToolResultEnvelope cached,
+    ToolCallEnvelope call)
+{
+    return new ToolResultEnvelope
+    {
+        CallId = call.CallId,
+        Tool = call.Tool,
+        Result = cached.Result,
+        MessageId = ToolResultEnvelope.CreateMessageId(call.CallId, call.Tool, call.SessionEpoch),
+        InReplyTo = call.MessageId,
+        SessionEpoch = call.SessionEpoch,
+        ActionNonce = cached.ActionNonce,
+    };
+}
+
+private static ToolResultEnvelope CloneForCache(ToolResultEnvelope result)
+{
+    return new ToolResultEnvelope
+    {
+        CallId = result.CallId,
+        Tool = result.Tool,
+        Result = result.Result,
+        MessageId = result.MessageId,
+        InReplyTo = result.InReplyTo,
+        SessionEpoch = result.SessionEpoch,
+        ActionNonce = result.ActionNonce,
+    };
+}
+
+private static string ReadStringArgOrNull(Dictionary<string, object> args, string name)
+{
+    if (args == null || !args.ContainsKey(name))
+    {
+        return null;
+    }
+    return args[name] as string;
+}
+```
+
+Change `ToolResultEnvelope.CreateMessageId` to `public static`.
+
+Update the existing `tests/test_mod_static_contracts.py::test_tool_result_error_envelopes_assign_non_null_message_id` assertion from:
+
+```python
+assert "private static string CreateMessageId(" in source
+```
+
+to:
+
+```python
+assert "public static string CreateMessageId(" in source
+```
+
+Add:
+
+```csharp
+public static class TerminalActionOutput
+{
+    public static Dictionary<string, object> Accepted(string actionKind)
+    {
+        Dictionary<string, object> output = Base(actionKind, true, "accepted");
+        output["execution_status"] = "accepted";
+        return output;
+    }
+
+    public static Dictionary<string, object> Stale(string acceptanceStatus)
+    {
+        Dictionary<string, object> output = Base("terminal_action", false, acceptanceStatus);
+        output["execution_status"] = "rejected";
+        return output;
+    }
+
+    private static Dictionary<string, object> Base(
+        string actionKind,
+        bool accepted,
+        string acceptanceStatus)
+    {
+        return new Dictionary<string, object>
+        {
+            { "accepted", accepted },
+            { "turn_complete", accepted },
+            { "action_kind", actionKind },
+            { "acceptance_status", acceptanceStatus },
+            { "safety_decision", accepted ? "pass" : "block" },
+        };
+    }
+}
+```
+
+In `BrainClient.RunLoop`, set the expected state version from the request before receiving tool calls:
+
+Add `using System.Globalization;` and `using System.Security.Cryptography;` to `BrainClient.cs`.
+
+```csharp
+toolRouter.SetExpectedTurnContext(
+    ParseDecisionInputTurn(pending.RequestJson),
+    ComputeDecisionInputSnapshotHash(pending.RequestJson));
+string response = ReceiveDecision(socket, pending.TimeoutMs, toolRouter);
+```
+
+Add a private helper to `BrainClient`:
+
+```csharp
+private static int ParseDecisionInputTurn(string requestJson)
+{
+    return ToolRouter.ReadTopLevelIntForTransport(requestJson, "turn");
+}
+
+private static string ComputeDecisionInputSnapshotHash(string requestJson)
+{
+    using (SHA256 sha = SHA256.Create())
+    {
+        byte[] bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(requestJson ?? ""));
+        StringBuilder sb = new StringBuilder(bytes.Length * 2);
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            sb.Append(bytes[i].ToString("x2", CultureInfo.InvariantCulture));
+        }
+        return sb.ToString();
+    }
+}
+```
+
+Expose the existing C# integer reader through a narrow `ToolRouter` helper:
+
+```csharp
+public static int ReadTopLevelIntForTransport(string json, string name)
+{
+    return ReadInt(json, name);
+}
+```
+
+- [ ] **Step 4: Run static tests to verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_mod_static_contracts.py -q
+```
+
+Expected: PASS.
+
+## Task 5: Python Telemetry Columns
+
+**Files:**
+- Modify: `brain/db/schema.py`
+- Modify: `brain/db/writer.py`
+- Test: `tests/test_brain_db.py`
+
+- [ ] **Step 1: Write failing telemetry tests**
+
+Add `"terminal_action"` to `TableName` only if a new table is created. This plan uses columns on existing tables, so keep `TableName` unchanged.
+
+Add this test to `tests/test_brain_db.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_telemetry_writer_records_terminal_idempotency_fields(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "telemetry.db"
+    writer = TelemetryWriter(TelemetryWriterConfig(path=db_path))
+    await writer.open()
+    try:
+        await writer.record_tool_call_sent(
+            call_id="call-exec-1",
+            tool="execute",
+            action_nonce="nonce-1",
+            state_version=284,
+            session_epoch=3,
+        )
+        await writer.record_tool_call_received(
+            call_id="call-exec-1",
+            tool="execute",
+            result_status="ok",
+            latency_ms=9,
+            action_nonce="nonce-1",
+            state_version=284,
+            session_epoch=3,
+            acceptance_status="stale",
+        )
+    finally:
+        await writer.close()
+
+    sent = await fetch_one(
+        db_path,
+        """
+        SELECT action_nonce, state_version, session_epoch
+        FROM tool_call_sent
+        WHERE call_id = 'call-exec-1'
+        """,
+    )
+    received = await fetch_one(
+        db_path,
+        """
+        SELECT action_nonce, state_version, session_epoch, acceptance_status
+        FROM tool_call_received
+        WHERE call_id = 'call-exec-1'
+        """,
+    )
+
+    assert dict(sent) == {
+        "action_nonce": "nonce-1",
+        "state_version": 284,
+        "session_epoch": 3,
+    }
+    assert dict(received) == {
+        "action_nonce": "nonce-1",
+        "state_version": 284,
+        "session_epoch": 3,
+        "acceptance_status": "stale",
+    }
+```
+
+- [ ] **Step 2: Run telemetry test to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_brain_db.py -k terminal_idempotency_fields -q
+```
+
+Expected: FAIL because writer methods do not accept terminal idempotency keyword arguments.
+
+- [ ] **Step 3: Implement telemetry columns and writer arguments**
+
+In `brain/db/schema.py`, add nullable columns to both `tool_call_sent` and `tool_call_received`:
+
+```sql
+action_nonce TEXT,
+state_version INTEGER,
+session_epoch INTEGER
+```
+
+Add this extra column only to `tool_call_received`:
+
+```sql
+acceptance_status TEXT
+```
+
+Add migration dictionaries for both tables:
+
+```python
+TOOL_CALL_SENT_COLUMN_MIGRATIONS = {
+    "action_nonce": "ALTER TABLE tool_call_sent ADD COLUMN action_nonce TEXT",
+    "state_version": "ALTER TABLE tool_call_sent ADD COLUMN state_version INTEGER",
+    "session_epoch": "ALTER TABLE tool_call_sent ADD COLUMN session_epoch INTEGER",
+}
+
+TOOL_CALL_RECEIVED_COLUMN_MIGRATIONS = {
+    "action_nonce": "ALTER TABLE tool_call_received ADD COLUMN action_nonce TEXT",
+    "state_version": "ALTER TABLE tool_call_received ADD COLUMN state_version INTEGER",
+    "session_epoch": "ALTER TABLE tool_call_received ADD COLUMN session_epoch INTEGER",
+    "acceptance_status": "ALTER TABLE tool_call_received ADD COLUMN acceptance_status TEXT",
+}
+```
+
+Ensure `create_all()` applies all three migration dictionaries.
+
+In `brain/db/writer.py`, extend `record_tool_call_sent()` and `record_tool_call_received()` with keyword-only optional arguments:
+
+```python
+action_nonce: str | None = None,
+state_version: int | None = None,
+session_epoch: int | None = None,
+acceptance_status: str | None = None,
+```
+
+Only `record_tool_call_received()` receives `acceptance_status`.
+
+- [ ] **Step 4: Run telemetry tests to verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_brain_db.py -k terminal_idempotency_fields -q
+```
+
+Expected: PASS.
+
+## Task 6: WebSocket Terminal Result Probe Coverage
+
+**Files:**
+- Modify: `brain/app.py`
+- Test: `tests/test_brain_app.py`
+
+- [ ] **Step 1: Write terminal result probe tests**
+
+Add fake-C# helper code and this test to `tests/test_brain_app.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_terminal_tool_call_result_is_exposed_to_decision_response() -> None:
+    tool_call, response = await run_fake_csharp_tool_roundtrip(
+        phase="tool_call_probe:execute",
+        result_status="ok",
+    )
+
+    assert tool_call["tool"] == "execute"
+    assert response["tool_result"]["action_nonce"] == tool_call["action_nonce"]
+    assert response["tool_result"]["output"]["acceptance_status"] == "accepted"
+```
+
+Then update `run_fake_csharp_tool_roundtrip()` to emit top-level `action_nonce` and `result.output` for terminal tools:
+
+```python
+if result_status == "ok" and tool_call["tool"] in {"execute", "navigate_to", "choose"}:
+    result["output"] = {
+        "accepted": True,
+        "turn_complete": True,
+        "action_kind": tool_call["tool"],
+        "execution_status": "accepted",
+        "acceptance_status": "accepted",
+        "safety_decision": "pass",
+    }
+    tool_result_action_nonce = tool_call["action_nonce"]
+elif result_status == "ok":
+    result["output"] = {"visible_tiles": 8}
+    tool_result_action_nonce = None
+```
+
+When building the fake `tool_result` JSON, include:
+
+```python
+                        "action_nonce": tool_result_action_nonce,
+```
+
+In `respond_for_phase()`, expose terminal result nonce in the probe response projection:
+
+```python
+        tool_result_payload = cast(
+            "JsonObject",
+            result.result.model_dump(mode="json", exclude_none=True),
+        )
+        if result.action_nonce is not None:
+            tool_result_payload["action_nonce"] = result.action_nonce
+        response["tool_result"] = cast("JsonValue", tool_result_payload)
+```
+
+- [ ] **Step 2: Run probe tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_brain_app.py -k terminal_tool_call_result_is_exposed -q
+```
+
+Expected: PASS after Task 2. If it fails because `tool_result.output` is missing, finish the helper update above.
+
+- [ ] **Step 3: Run focused PR-3 test set**
+
+Run:
+
+```bash
+uv run pytest tests/test_protocol_messages.py tests/test_brain_app.py tests/test_brain_db.py tests/test_mod_static_contracts.py -q
+```
+
+Expected: PASS.
+
+## Task 7: Full Verification
+
+**Files:**
+- No source files changed in this task.
+
+- [ ] **Step 1: Run full Python tests**
+
+Run:
+
+```bash
+uv run pytest tests/
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run repo static gate**
+
+Run:
+
+```bash
+pre-commit run --all-files
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect git diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- docs/superpowers/plans/2026-04-29-phase-1-pr-3-terminal-action-idempotency.md brain/protocol.py brain/app.py brain/db/schema.py brain/db/writer.py mod/LLMOfQud/ToolRouter.cs mod/LLMOfQud/BrainClient.cs tests/test_protocol_messages.py tests/test_brain_app.py tests/test_brain_db.py tests/test_mod_static_contracts.py
+```
+
+Expected: Only PR-3 scoped files are changed. Do not commit unless the user explicitly requests a commit.
+
+## Self-Review
+
+- Spec coverage: Tasks 1-2 cover top-level terminal envelope fields and probe `snapshot_hash`; Task 3 covers optional C# parsing that preserves non-terminal PR-2 calls; Task 4 covers stale epoch, nonce cache, minimum terminal `message_id` dedup, duplicate turn suppression, snapshot hash checking, and terminal output; Task 5 covers telemetry; Task 6 covers no-LLM WebSocket exposure; Task 7 covers verification.
+- Explicit deferrals: Non-terminal deduplication, Phase 2a provider execution, real game action handlers, pathfinding, reconnect hardening beyond stale epoch rejection, and `cancel_or_back` terminalization are out of scope.
+- ADR status: No ADR is created because ADR 0011 states PR-3 needs no new ADR; this plan follows the frozen v5.9 contract.

--- a/docs/superpowers/plans/2026-04-29-phase-1-pr-3-terminal-action-idempotency.md
+++ b/docs/superpowers/plans/2026-04-29-phase-1-pr-3-terminal-action-idempotency.md
@@ -16,7 +16,7 @@
 - `docs/architecture-v5.md:2486-2516` shows the terminal action example and the terminal result output contract.
 - `docs/architecture-v5.md:2863-2877` defines Phase 1-G: cache by `(session_epoch, action_nonce)`, reject stale `state_version`, reject stale `session_epoch`, minimum terminal-action `message_id` dedup, duplicate turn suppression, and defer non-terminal deduplication to Phase 2b.
 - `docs/architecture-v5.md:2905-2909` makes Phase 1-G a hard prerequisite before Phase 2a Gate 1.
-- `docs/adr/0011-phase-1-pr-1-scope.md:85-89` says PR-3 requires no new ADR because v5.9 carries the contract.
+- `docs/adr/0017-phase-1-pr-3-terminal-action-idempotency.md:20-53` records the PR-3 terminal action idempotency governance decision.
 - `docs/adr/0015-phase-1-pr-2-readiness-scope.md:94-99` confirms PR-2 intentionally deferred this behavior.
 
 ## File Structure
@@ -1060,4 +1060,4 @@ Expected: Only PR-3 scoped files are changed. Do not commit unless the user expl
 
 - Spec coverage: Tasks 1-2 cover top-level terminal envelope fields and probe `snapshot_hash`; Task 3 covers optional C# parsing that preserves non-terminal PR-2 calls; Task 4 covers stale epoch, nonce cache, minimum terminal `message_id` dedup, duplicate turn suppression, snapshot hash checking, and terminal output; Task 5 covers telemetry; Task 6 covers no-LLM WebSocket exposure; Task 7 covers verification.
 - Explicit deferrals: Non-terminal deduplication, Phase 2a provider execution, real game action handlers, pathfinding, reconnect hardening beyond stale epoch rejection, and `cancel_or_back` terminalization are out of scope.
-- ADR status: No ADR is created because ADR 0011 states PR-3 needs no new ADR; this plan follows the frozen v5.9 contract.
+- ADR status: ADR 0017 records the PR-3 terminal action idempotency governance decision and links this plan to the frozen v5.9 contract.

--- a/mod/LLMOfQud/BrainClient.cs
+++ b/mod/LLMOfQud/BrainClient.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Net.WebSockets;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -161,6 +163,9 @@ namespace LLMOfQud
                     Stopwatch stopwatch = Stopwatch.StartNew();
                     ClientWebSocket socket = EnsureConnected();
                     Send(socket, pending.RequestJson, pending.TimeoutMs);
+                    toolRouter.SetExpectedTurnContext(
+                        ParseDecisionInputTurn(pending.RequestJson),
+                        ComputeDecisionInputSnapshotHash(pending.RequestJson));
                     string response = ReceiveDecision(socket, pending.TimeoutMs, toolRouter);
                     stopwatch.Stop();
                     pending.Completion.TrySetResult(response);
@@ -333,6 +338,25 @@ namespace LLMOfQud
                     continue;
                 }
                 return responseJson;
+            }
+        }
+
+        private static int ParseDecisionInputTurn(string requestJson)
+        {
+            return ToolRouter.ReadTopLevelIntForTransport(requestJson, "turn");
+        }
+
+        private static string ComputeDecisionInputSnapshotHash(string requestJson)
+        {
+            using (SHA256 sha = SHA256.Create())
+            {
+                byte[] bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(requestJson ?? ""));
+                StringBuilder sb = new StringBuilder(bytes.Length * 2);
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    sb.Append(bytes[i].ToString("x2", CultureInfo.InvariantCulture));
+                }
+                return sb.ToString();
             }
         }
 

--- a/mod/LLMOfQud/ToolRouter.cs
+++ b/mod/LLMOfQud/ToolRouter.cs
@@ -9,6 +9,32 @@ namespace LLMOfQud
     {
         public const bool TerminalActionParallelDispatchEnabled = false;
 
+        private readonly Func<int> _sessionEpochProvider;
+        private readonly Dictionary<string, ToolResultEnvelope> _terminalActionCache =
+            new Dictionary<string, ToolResultEnvelope>();
+        private readonly Dictionary<string, ToolResultEnvelope> _terminalMessageCache =
+            new Dictionary<string, ToolResultEnvelope>();
+        private readonly HashSet<int> _completedTerminalStateVersions = new HashSet<int>();
+        private int _expectedStateVersion;
+        private string _expectedSnapshotHash;
+
+        public ToolRouter() : this(() => 1)
+        {
+        }
+
+        public ToolRouter(Func<int> sessionEpochProvider)
+        {
+            _sessionEpochProvider = sessionEpochProvider ?? (() => 1);
+            _expectedStateVersion = 0;
+            _expectedSnapshotHash = null;
+        }
+
+        public void SetExpectedTurnContext(int stateVersion, string snapshotHash)
+        {
+            _expectedStateVersion = stateVersion;
+            _expectedSnapshotHash = snapshotHash;
+        }
+
         public ToolResultEnvelope Dispatch(ToolCallEnvelope call)
         {
             if (call == null)
@@ -20,6 +46,70 @@ namespace LLMOfQud
                     0,
                     "invalid_tool_call",
                     "Tool call envelope is required");
+            }
+
+            if (IsTerminalAction(call.Tool))
+            {
+                if (call.ActionNonce == null || !call.StateVersion.HasValue)
+                {
+                    return TerminalActionResult(
+                        call,
+                        TerminalActionOutput.Stale("stale"),
+                        "terminal action requires action_nonce and state_version");
+                }
+
+                if (call.SessionEpoch != _sessionEpochProvider())
+                {
+                    return TerminalActionResult(
+                        call,
+                        TerminalActionOutput.Stale("stale_epoch"),
+                        "terminal action belongs to a stale session epoch");
+                }
+
+                ToolResultEnvelope cached;
+                if (_terminalMessageCache.TryGetValue(call.MessageId, out cached))
+                {
+                    return CloneForDuplicateRequest(cached, call);
+                }
+
+                string cacheKey = TerminalActionCacheKey(call.SessionEpoch, call.ActionNonce);
+                if (_terminalActionCache.TryGetValue(cacheKey, out cached))
+                {
+                    return CloneForDuplicateRequest(cached, call);
+                }
+
+                if (call.StateVersion.Value != _expectedStateVersion)
+                {
+                    return TerminalActionResult(
+                        call,
+                        TerminalActionOutput.Stale("stale"),
+                        "terminal action belongs to a stale state version");
+                }
+
+                if (ReadStringArgOrNull(call.Args, "snapshot_hash") != _expectedSnapshotHash)
+                {
+                    return TerminalActionResult(
+                        call,
+                        TerminalActionOutput.Stale("stale"),
+                        "terminal action snapshot_hash does not match current state");
+                }
+
+                if (_completedTerminalStateVersions.Contains(call.StateVersion.Value))
+                {
+                    return TerminalActionResult(
+                        call,
+                        TerminalActionOutput.Stale("duplicate"),
+                        "terminal action already completed for this state version");
+                }
+
+                ToolResultEnvelope result = TerminalActionResult(
+                    call,
+                    TerminalActionOutput.Accepted(call.Tool),
+                    null);
+                _terminalActionCache[cacheKey] = CloneForCache(result);
+                _terminalMessageCache[call.MessageId] = CloneForCache(result);
+                _completedTerminalStateVersions.Add(call.StateVersion.Value);
+                return result;
             }
 
             return ToolResultEnvelope.FromError(
@@ -38,6 +128,53 @@ namespace LLMOfQud
                 return true;
             }
             return TerminalActionParallelDispatchEnabled;
+        }
+
+        private static ToolResultEnvelope TerminalActionResult(
+            ToolCallEnvelope call,
+            Dictionary<string, object> output,
+            string errorMessage)
+        {
+            return new ToolResultEnvelope
+            {
+                CallId = call.CallId,
+                Tool = call.Tool,
+                Result = ToolResult.Ok(output),
+                MessageId = ToolResultEnvelope.CreateMessageId(call.CallId, call.Tool, call.SessionEpoch),
+                InReplyTo = call.MessageId,
+                SessionEpoch = call.SessionEpoch,
+                ActionNonce = call.ActionNonce,
+            };
+        }
+
+        private static ToolResultEnvelope CloneForDuplicateRequest(
+            ToolResultEnvelope cached,
+            ToolCallEnvelope call)
+        {
+            return new ToolResultEnvelope
+            {
+                CallId = call.CallId,
+                Tool = call.Tool,
+                Result = cached.Result,
+                MessageId = ToolResultEnvelope.CreateMessageId(call.CallId, call.Tool, call.SessionEpoch),
+                InReplyTo = call.MessageId,
+                SessionEpoch = call.SessionEpoch,
+                ActionNonce = cached.ActionNonce,
+            };
+        }
+
+        private static ToolResultEnvelope CloneForCache(ToolResultEnvelope result)
+        {
+            return new ToolResultEnvelope
+            {
+                CallId = result.CallId,
+                Tool = result.Tool,
+                Result = result.Result,
+                MessageId = result.MessageId,
+                InReplyTo = result.InReplyTo,
+                SessionEpoch = result.SessionEpoch,
+                ActionNonce = result.ActionNonce,
+            };
         }
 
         private static bool IsTerminalAction(string tool)
@@ -89,7 +226,14 @@ namespace LLMOfQud
                 Args = ReadArgs(json),
                 MessageId = ReadStringOrNull(json, ToolProtocolFields.FieldMessageId),
                 SessionEpoch = ReadInt(json, ToolProtocolFields.FieldSessionEpoch),
+                ActionNonce = ReadOptionalString(json, ToolProtocolFields.FieldActionNonce),
+                StateVersion = ReadNullableInt(json, ToolProtocolFields.FieldStateVersion),
             };
+        }
+
+        public static int ReadTopLevelIntForTransport(string json, string name)
+        {
+            return ReadInt(json, name);
         }
 
         public static SupervisorResponseEnvelope ParseSupervisorResponseEnvelope(string json)
@@ -180,6 +324,11 @@ namespace LLMOfQud
             AppendJsonProperty(sb, ToolProtocolFields.FieldInReplyTo, envelope.InReplyTo);
             sb.Append(',');
             AppendJsonProperty(sb, ToolProtocolFields.FieldSessionEpoch, envelope.SessionEpoch);
+            if (envelope.ActionNonce != null)
+            {
+                sb.Append(',');
+                AppendJsonProperty(sb, ToolProtocolFields.FieldActionNonce, envelope.ActionNonce);
+            }
             sb.Append(',');
             AppendJsonPropertyName(sb, ToolProtocolFields.FieldResult);
             sb.Append('{');
@@ -344,6 +493,38 @@ namespace LLMOfQud
             return UnescapeSimple(json.Substring(index + 1, end - index - 1));
         }
 
+        private static string ReadOptionalString(string json, string name)
+        {
+            try
+            {
+                return ReadStringOrNull(json, name);
+            }
+            catch (DisconnectedException ex)
+            {
+                if (ex.Message == "JSON field missing: " + name)
+                {
+                    return null;
+                }
+                throw;
+            }
+        }
+
+        private static int? ReadNullableInt(string json, string name)
+        {
+            try
+            {
+                return ReadInt(json, name);
+            }
+            catch (DisconnectedException ex)
+            {
+                if (ex.Message == "JSON field missing: " + name)
+                {
+                    return null;
+                }
+                throw;
+            }
+        }
+
         private static string ReadRequiredString(string json, string name)
         {
             string value = ReadStringOrNull(json, name);
@@ -369,6 +550,20 @@ namespace LLMOfQud
                 throw;
             }
             throw new DisconnectedException("Unsupported legacy tool_call field: " + name);
+        }
+
+        private static string TerminalActionCacheKey(int sessionEpoch, string actionNonce)
+        {
+            return sessionEpoch.ToString(CultureInfo.InvariantCulture) + ":" + actionNonce;
+        }
+
+        private static string ReadStringArgOrNull(Dictionary<string, object> args, string name)
+        {
+            if (args == null || !args.ContainsKey(name))
+            {
+                return null;
+            }
+            return args[name] as string;
         }
 
         private static int FindTopLevelValue(string json, string name)
@@ -753,6 +948,8 @@ namespace LLMOfQud
         public const string FieldMessageId = "message_id";
         public const string FieldInReplyTo = "in_reply_to";
         public const string FieldSessionEpoch = "session_epoch";
+        public const string FieldActionNonce = "action_nonce";
+        public const string FieldStateVersion = "state_version";
         public const string FieldStatus = "status";
         public const string FieldOutput = "output";
         public const string FieldErrorCode = "error_code";
@@ -780,6 +977,8 @@ namespace LLMOfQud
         public Dictionary<string, object> Args;
         public string MessageId;
         public int SessionEpoch;
+        public string ActionNonce;
+        public int? StateVersion;
     }
 
     public sealed class SupervisorRequestEnvelope
@@ -811,6 +1010,7 @@ namespace LLMOfQud
         public string MessageId = CreateMessageId(null, null, 0);
         public string InReplyTo;
         public int SessionEpoch;
+        public string ActionNonce;
 
         public static ToolResultEnvelope FromError(
             string callId,
@@ -831,7 +1031,7 @@ namespace LLMOfQud
             };
         }
 
-        private static string CreateMessageId(string callId, string tool, int sessionEpoch)
+        public static string CreateMessageId(string callId, string tool, int sessionEpoch)
         {
             return "tool_result:" +
                 (callId ?? "no_call") + ":" +
@@ -872,6 +1072,38 @@ namespace LLMOfQud
                 Output = null,
                 ErrorCode = errorCode,
                 ErrorMessage = errorMessage,
+            };
+        }
+    }
+
+    public static class TerminalActionOutput
+    {
+        public static Dictionary<string, object> Accepted(string actionKind)
+        {
+            Dictionary<string, object> output = Base(actionKind, true, "accepted");
+            output["execution_status"] = "accepted";
+            return output;
+        }
+
+        public static Dictionary<string, object> Stale(string acceptanceStatus)
+        {
+            Dictionary<string, object> output = Base("terminal_action", false, acceptanceStatus);
+            output["execution_status"] = "rejected";
+            return output;
+        }
+
+        private static Dictionary<string, object> Base(
+            string actionKind,
+            bool accepted,
+            string acceptanceStatus)
+        {
+            return new Dictionary<string, object>
+            {
+                { "accepted", accepted },
+                { "turn_complete", accepted },
+                { "action_kind", actionKind },
+                { "acceptance_status", acceptanceStatus },
+                { "safety_decision", accepted ? "pass" : "block" },
             };
         }
     }

--- a/mod/LLMOfQud/ToolRouter.cs
+++ b/mod/LLMOfQud/ToolRouter.cs
@@ -54,7 +54,7 @@ namespace LLMOfQud
                 {
                     return TerminalActionResult(
                         call,
-                        TerminalActionOutput.Stale("stale"),
+                        TerminalActionOutput.Stale(call.Tool, "stale"),
                         "terminal action requires action_nonce and state_version");
                 }
 
@@ -62,7 +62,7 @@ namespace LLMOfQud
                 {
                     return TerminalActionResult(
                         call,
-                        TerminalActionOutput.Stale("stale_epoch"),
+                        TerminalActionOutput.Stale(call.Tool, "stale_epoch"),
                         "terminal action belongs to a stale session epoch");
                 }
 
@@ -82,7 +82,7 @@ namespace LLMOfQud
                 {
                     return TerminalActionResult(
                         call,
-                        TerminalActionOutput.Stale("stale"),
+                        TerminalActionOutput.Stale(call.Tool, "stale"),
                         "terminal action belongs to a stale state version");
                 }
 
@@ -90,7 +90,7 @@ namespace LLMOfQud
                 {
                     return TerminalActionResult(
                         call,
-                        TerminalActionOutput.Stale("stale"),
+                        TerminalActionOutput.Stale(call.Tool, "stale"),
                         "terminal action snapshot_hash does not match current state");
                 }
 
@@ -98,7 +98,7 @@ namespace LLMOfQud
                 {
                     return TerminalActionResult(
                         call,
-                        TerminalActionOutput.Stale("duplicate"),
+                        TerminalActionOutput.Stale(call.Tool, "duplicate"),
                         "terminal action already completed for this state version");
                 }
 
@@ -1085,9 +1085,11 @@ namespace LLMOfQud
             return output;
         }
 
-        public static Dictionary<string, object> Stale(string acceptanceStatus)
+        public static Dictionary<string, object> Stale(
+            string actionKind,
+            string acceptanceStatus)
         {
-            Dictionary<string, object> output = Base("terminal_action", false, acceptanceStatus);
+            Dictionary<string, object> output = Base(actionKind, false, acceptanceStatus);
             output["execution_status"] = "rejected";
             return output;
         }

--- a/tests/test_brain_app.py
+++ b/tests/test_brain_app.py
@@ -36,6 +36,11 @@ if TYPE_CHECKING:
     from brain.protocol import JsonObject, JsonValue
 
 
+def require_test_json_object(value: JsonValue) -> JsonObject:
+    assert isinstance(value, dict)
+    return value
+
+
 def minimal_decision_input(turn: int = 7) -> JsonObject:
     return {
         "schema": "decision_input.v1",
@@ -84,7 +89,21 @@ async def run_fake_csharp_tool_roundtrip(
             await websocket.send(json.dumps(minimal_decision_input()))
             tool_call = cast("JsonObject", json.loads(await websocket.recv()))
             result: JsonObject = {"status": result_status}
-            if result_status == "ok":
+            terminal_tool = tool_call["tool"] in {"execute", "navigate_to", "choose"}
+            if terminal_tool:
+                tool_result_action_nonce = tool_call["action_nonce"]
+            else:
+                tool_result_action_nonce = None
+            if result_status == "ok" and terminal_tool:
+                result["output"] = {
+                    "accepted": True,
+                    "turn_complete": True,
+                    "action_kind": tool_call["tool"],
+                    "execution_status": "accepted",
+                    "acceptance_status": "accepted",
+                    "safety_decision": "pass",
+                }
+            elif result_status == "ok":
                 result["output"] = {"visible_tiles": 8}
             else:
                 result["error_code"] = error_code
@@ -99,6 +118,7 @@ async def run_fake_csharp_tool_roundtrip(
                         "message_id": "fake-csharp-result-1",
                         "in_reply_to": tool_call["message_id"],
                         "session_epoch": tool_call["session_epoch"],
+                        "action_nonce": tool_result_action_nonce,
                     },
                 ),
             )
@@ -213,9 +233,10 @@ async def test_fake_csharp_malformed_args_failure_uses_deterministic_validation_
     )
 
     assert tool_call["tool"] == "execute"
-    assert tool_call["args"] == {"candidate_id": 123}
-    tool_result = response["tool_result"]
-    assert isinstance(tool_result, dict)
+    tool_args = require_test_json_object(tool_call["args"])
+    assert tool_args["candidate_id"] == 123
+    assert isinstance(tool_args["snapshot_hash"], str)
+    tool_result = require_test_json_object(response["tool_result"])
     assert tool_result["error_code"] == MALFORMED_TOOL_ARGS_ERROR_CODE
 
 
@@ -226,6 +247,47 @@ async def test_python_emits_game_tool_call_instead_of_dispatching_it_locally() -
     assert tool_call["type"] == "tool_call"
     assert tool_call["tool"] == "check_status"
     assert response["schema"] == "decision.v1"
+
+
+@pytest.mark.asyncio
+async def test_terminal_tool_call_probe_includes_action_nonce_and_state_version() -> None:
+    tool_call, response = await run_fake_csharp_tool_roundtrip(
+        phase="tool_call_probe:execute",
+    )
+
+    assert tool_call["tool"] == "execute"
+    assert tool_call["action_nonce"] == "turn-7-execute-nonce"
+    assert tool_call["state_version"] == 7
+    tool_args = require_test_json_object(tool_call["args"])
+    assert isinstance(tool_args["snapshot_hash"], str)
+    assert response["schema"] == "decision.v1"
+
+
+def test_terminal_tool_call_batch_uses_deterministic_nonce_and_state_version() -> None:
+    (message,) = build_tool_call_messages(
+        [{"tool": "execute", "args": {"candidate_id": "c1"}, "call_id": "call-1"}],
+        turn=7,
+        session_epoch=3,
+        snapshot_hash="snapshot-7",
+    )
+
+    assert message.action_nonce == "turn-7-execute-nonce"
+    assert message.state_version == 7
+    assert message.args["snapshot_hash"] == "snapshot-7"
+
+
+@pytest.mark.asyncio
+async def test_terminal_tool_call_result_is_exposed_to_decision_response() -> None:
+    tool_call, response = await run_fake_csharp_tool_roundtrip(
+        phase="tool_call_probe:execute",
+        result_status="ok",
+    )
+
+    assert tool_call["tool"] == "execute"
+    tool_result = require_test_json_object(response["tool_result"])
+    tool_result_output = require_test_json_object(tool_result["output"])
+    assert tool_result["action_nonce"] == tool_call["action_nonce"]
+    assert tool_result_output["acceptance_status"] == "accepted"
 
 
 def test_more_than_one_terminal_action_is_rejected_before_emission() -> None:
@@ -271,6 +333,35 @@ def test_tool_result_session_epoch_must_match_tool_call() -> None:
     with pytest.raises(
         ToolResultMismatchError,
         match=r"tool_result session_epoch mismatch: expected 3, got 4",
+    ):
+        require_matching_tool_result(tool_call, tool_result)
+
+
+@pytest.mark.parametrize("action_nonce", [None, "wrong-nonce"])
+def test_terminal_tool_result_action_nonce_must_match_tool_call(
+    action_nonce: str | None,
+) -> None:
+    (tool_call,) = build_tool_call_messages(
+        [{"tool": "execute", "args": {"candidate_id": "c1"}, "call_id": "call-1"}],
+        turn=7,
+        session_epoch=3,
+    )
+    tool_result = ToolResultMessage(
+        call_id=tool_call.call_id,
+        tool=tool_call.tool,
+        result=ToolResultPayload(status=ToolResultStatus.OK),
+        message_id="result-1",
+        in_reply_to=tool_call.message_id,
+        session_epoch=tool_call.session_epoch,
+        action_nonce=action_nonce,
+    )
+
+    with pytest.raises(
+        ToolResultMismatchError,
+        match=(
+            r"tool_result action_nonce mismatch: "
+            r"expected 'turn-7-execute-nonce', got "
+        ),
     ):
         require_matching_tool_result(tool_call, tool_result)
 

--- a/tests/test_brain_db.py
+++ b/tests/test_brain_db.py
@@ -192,6 +192,64 @@ async def test_telemetry_writer_records_tool_call_sent_and_received(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_telemetry_writer_records_terminal_idempotency_fields(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "telemetry.db"
+    writer = TelemetryWriter(TelemetryWriterConfig(path=db_path))
+    await writer.open()
+    try:
+        await writer.record_tool_call_sent(
+            call_id="call-exec-1",
+            tool="execute",
+            action_nonce="nonce-1",
+            state_version=284,
+            session_epoch=3,
+        )
+        await writer.record_tool_call_received(
+            call_id="call-exec-1",
+            tool="execute",
+            result_status="ok",
+            latency_ms=9,
+            action_nonce="nonce-1",
+            state_version=284,
+            session_epoch=3,
+            acceptance_status="stale",
+        )
+    finally:
+        await writer.close()
+
+    sent = await fetch_one(
+        db_path,
+        """
+        SELECT action_nonce, state_version, session_epoch
+        FROM tool_call_sent
+        WHERE call_id = 'call-exec-1'
+        """,
+    )
+    received = await fetch_one(
+        db_path,
+        """
+        SELECT action_nonce, state_version, session_epoch, acceptance_status
+        FROM tool_call_received
+        WHERE call_id = 'call-exec-1'
+        """,
+    )
+
+    assert dict(sent) == {
+        "action_nonce": "nonce-1",
+        "state_version": 284,
+        "session_epoch": 3,
+    }
+    assert dict(received) == {
+        "action_nonce": "nonce-1",
+        "state_version": 284,
+        "session_epoch": 3,
+        "acceptance_status": "stale",
+    }
+
+
+@pytest.mark.asyncio
 async def test_decision_response_records_optional_provider_and_retry_metadata(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_mod_static_contracts.py
+++ b/tests/test_mod_static_contracts.py
@@ -215,6 +215,41 @@ def test_tool_call_envelope_declares_required_wire_fields() -> None:
     assert "public int SessionEpoch;" in source
 
 
+def test_tool_call_envelope_declares_terminal_idempotency_fields() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    parse_body = method_body(source, "public static ToolCallEnvelope ParseToolCallEnvelope")
+    build_body = method_body(source, "public static string BuildToolResultJson")
+
+    assert 'FieldActionNonce = "action_nonce"' in source
+    assert 'FieldStateVersion = "state_version"' in source
+    assert "ActionNonce = ReadOptionalString(json, ToolProtocolFields.FieldActionNonce)" in parse_body
+    assert "StateVersion = ReadNullableInt(json, ToolProtocolFields.FieldStateVersion)" in parse_body
+    assert "AppendJsonProperty(sb, ToolProtocolFields.FieldActionNonce, envelope.ActionNonce)" in build_body
+    assert "public string ActionNonce;" in source
+    assert "public int? StateVersion;" in source
+    assert "private static string ReadOptionalString" in source
+
+
+def test_toolrouter_parses_non_terminal_tool_call_without_idempotency_fields() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    parse_body = method_body(source, "public static ToolCallEnvelope ParseToolCallEnvelope")
+
+    assert "ActionNonce = ReadOptionalString(json, ToolProtocolFields.FieldActionNonce)" in parse_body
+    assert "StateVersion = ReadNullableInt(json, ToolProtocolFields.FieldStateVersion)" in parse_body
+    assert "JSON field missing: \" + name" in source
+
+
+def test_terminal_idempotency_cache_key_is_session_epoch_and_action_nonce() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+
+    assert "private readonly Dictionary<string, ToolResultEnvelope> _terminalActionCache" in source
+    assert "TerminalActionCacheKey(call.SessionEpoch, call.ActionNonce)" in source
+    assert (
+        'return sessionEpoch.ToString(CultureInfo.InvariantCulture) + ":" + actionNonce;'
+        in source
+    )
+
+
 def test_tool_call_envelope_rejects_legacy_top_level_tid() -> None:
     source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
     parse_body = method_body(source, "public static ToolCallEnvelope ParseToolCallEnvelope")
@@ -247,7 +282,7 @@ def test_tool_result_error_envelopes_assign_non_null_message_id() -> None:
     assert "public string MessageId = CreateMessageId(" in envelope_body
     assert "MessageId = CreateMessageId(" in body
     assert "MessageId = null" not in body
-    assert "private static string CreateMessageId(" in source
+    assert "public static string CreateMessageId(" in source
 
 
 def test_tool_result_declares_normalized_status_output_and_error_fields() -> None:
@@ -431,6 +466,56 @@ def test_only_execute_navigate_to_and_choose_are_terminal_actions() -> None:
     assert 'case "choose":' in terminal_body
     assert 'case "cancel_or_back":' not in terminal_body
     assert "return TerminalActionParallelDispatchEnabled;" in parallel_body
+
+
+def test_toolrouter_rejects_stale_terminal_actions_before_dispatch() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    dispatch_body = method_body(source, "public ToolResultEnvelope Dispatch")
+
+    assert "_sessionEpochProvider" in source
+    assert 'TerminalActionOutput.Stale("stale_epoch")' in dispatch_body
+    assert 'TerminalActionOutput.Stale("stale")' in dispatch_body
+    assert "call.SessionEpoch != _sessionEpochProvider()" in dispatch_body
+    assert "call.StateVersion.Value != _expectedStateVersion" in dispatch_body
+
+
+def test_toolrouter_returns_cached_duplicate_terminal_action_result() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    dispatch_body = method_body(source, "public ToolResultEnvelope Dispatch")
+
+    assert "_terminalActionCache.TryGetValue(cacheKey, out cached)" in dispatch_body
+    assert "_terminalMessageCache.TryGetValue(call.MessageId, out cached)" in dispatch_body
+    assert "CloneForDuplicateRequest(cached, call)" in dispatch_body
+    assert "_terminalActionCache[cacheKey] = CloneForCache(result)" in dispatch_body
+    assert "_terminalMessageCache[call.MessageId] = CloneForCache(result)" in dispatch_body
+    assert "TerminalActionOutput.Accepted(call.Tool)" in dispatch_body
+
+
+def test_toolrouter_suppresses_duplicate_terminal_turn_and_checks_snapshot_hash() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+    dispatch_body = method_body(source, "public ToolResultEnvelope Dispatch")
+
+    assert "_completedTerminalStateVersions.Contains(call.StateVersion.Value)" in dispatch_body
+    assert 'TerminalActionOutput.Stale("duplicate")' in dispatch_body
+    assert 'ReadStringArgOrNull(call.Args, "snapshot_hash")' in dispatch_body
+    assert "!= _expectedSnapshotHash" in dispatch_body
+    assert "_completedTerminalStateVersions.Add(call.StateVersion.Value)" in dispatch_body
+
+
+def test_brainclient_sets_expected_state_version_and_snapshot_hash_before_receive() -> None:
+    source = (ROOT / "mod/LLMOfQud/BrainClient.cs").read_text()
+    run_loop_body = method_body(source, "private void RunLoop()")
+
+    assert "toolRouter.SetExpectedTurnContext(" in run_loop_body
+    assert "ParseDecisionInputTurn(pending.RequestJson)" in run_loop_body
+    assert "ComputeDecisionInputSnapshotHash(pending.RequestJson)" in run_loop_body
+
+
+def test_tool_result_message_id_factory_is_public_for_cached_terminal_results() -> None:
+    source = (ROOT / "mod/LLMOfQud/ToolRouter.cs").read_text()
+
+    assert "public static string CreateMessageId(" in source
+    assert "private static string CreateMessageId(" not in source
 
 
 def test_unknown_tool_errors_use_protocol_error_code() -> None:

--- a/tests/test_mod_static_contracts.py
+++ b/tests/test_mod_static_contracts.py
@@ -473,8 +473,8 @@ def test_toolrouter_rejects_stale_terminal_actions_before_dispatch() -> None:
     dispatch_body = method_body(source, "public ToolResultEnvelope Dispatch")
 
     assert "_sessionEpochProvider" in source
-    assert 'TerminalActionOutput.Stale("stale_epoch")' in dispatch_body
-    assert 'TerminalActionOutput.Stale("stale")' in dispatch_body
+    assert 'TerminalActionOutput.Stale(call.Tool, "stale_epoch")' in dispatch_body
+    assert 'TerminalActionOutput.Stale(call.Tool, "stale")' in dispatch_body
     assert "call.SessionEpoch != _sessionEpochProvider()" in dispatch_body
     assert "call.StateVersion.Value != _expectedStateVersion" in dispatch_body
 
@@ -496,7 +496,7 @@ def test_toolrouter_suppresses_duplicate_terminal_turn_and_checks_snapshot_hash(
     dispatch_body = method_body(source, "public ToolResultEnvelope Dispatch")
 
     assert "_completedTerminalStateVersions.Contains(call.StateVersion.Value)" in dispatch_body
-    assert 'TerminalActionOutput.Stale("duplicate")' in dispatch_body
+    assert 'TerminalActionOutput.Stale(call.Tool, "duplicate")' in dispatch_body
     assert 'ReadStringArgOrNull(call.Args, "snapshot_hash")' in dispatch_body
     assert "!= _expectedSnapshotHash" in dispatch_body
     assert "_completedTerminalStateVersions.Add(call.StateVersion.Value)" in dispatch_body

--- a/tests/test_protocol_messages.py
+++ b/tests/test_protocol_messages.py
@@ -191,6 +191,62 @@ def test_provider_specific_ids_are_not_top_level_protocol_fields() -> None:
         )
 
 
+def test_terminal_tool_call_requires_action_nonce_and_state_version() -> None:
+    base_message: JsonObject = {
+        "type": "tool_call",
+        "call_id": "turn-7-call-1",
+        "tool": "execute",
+        "args": {"candidate_id": "c1"},
+        "message_id": "msg-7-call-1",
+        "session_epoch": 3,
+    }
+
+    with pytest.raises(ValidationError, match="action_nonce"):
+        ToolCallMessage.model_validate(base_message)
+    with pytest.raises(ValidationError, match="state_version"):
+        ToolCallMessage.model_validate(base_message | {"action_nonce": "nonce-7"})
+
+    message = ToolCallMessage.model_validate(
+        base_message | {"action_nonce": "nonce-7", "state_version": 284},
+    )
+
+    assert message.action_nonce == "nonce-7"
+    assert message.state_version == 284
+
+
+def test_non_terminal_tool_call_does_not_require_terminal_idempotency_fields() -> None:
+    message = ToolCallMessage.model_validate(
+        {
+            "type": "tool_call",
+            "call_id": "turn-7-call-1",
+            "tool": "inspect_surroundings",
+            "args": {},
+            "message_id": "msg-7-call-1",
+            "session_epoch": 3,
+        },
+    )
+
+    assert message.action_nonce is None
+    assert message.state_version is None
+
+
+def test_terminal_tool_result_can_echo_action_nonce() -> None:
+    message = ToolResultMessage.model_validate(
+        {
+            "type": "tool_result",
+            "call_id": "turn-7-call-1",
+            "tool": "execute",
+            "result": {"status": "ok", "output": {"acceptance_status": "accepted"}},
+            "message_id": "msg-7-result-1",
+            "in_reply_to": "msg-7-call-1",
+            "session_epoch": 3,
+            "action_nonce": "nonce-7",
+        },
+    )
+
+    assert message.action_nonce == "nonce-7"
+
+
 def test_tool_call_rejects_legacy_top_level_tid() -> None:
     with pytest.raises(ValidationError, match="tid"):
         ToolCallMessage.model_validate(


### PR DESCRIPTION
## Summary
- Add terminal action idempotency fields and validation for `execute`, `navigate_to`, and `choose` tool calls.
- Enforce C# terminal action caching/rejection for duplicate nonces, duplicate message IDs, stale state versions, stale session epochs, and snapshot mismatches.
- Extend Brain telemetry persistence, protocol tests, C# static contract tests, and add the PR-3 plan plus E2E acceptance memo.

## Test Plan
- [x] `pre-commit run --all-files`
- [x] `uv run pytest tests/`
- [x] `pre-commit run`
- [x] `git diff --cached --check`
- [x] In-game E2E happy path: Roslyn compile succeeded, `tool_call_probe:execute` completed 330 request/response/decision cycles, `disconnect_pause=0`

## Notes
- In-game E2E covers the terminal tool-call happy path.
- Adversarial duplicate/stale/snapshot-mismatch branches are covered by automated tests; a dedicated in-game adversarial probe phase is left as future work if runtime evidence for each rejection branch is needed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/llm-of-qud/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic idempotency for terminal actions (`execute`, `navigate_to`, `choose`) using decision-input snapshot hashing with `action_nonce`/`state_version`, including stale/duplicate rejection and consistent terminal-result reuse.
  * Extended protocol/tool-message validation so terminal tool calls/results carry and verify idempotency metadata, surfaced through responses.
  * Enhanced tool-call telemetry persistence to record the new idempotency fields.

* **Tests**
  * Expanded terminal idempotency coverage across protocol validation, probe/transport flows, DB persistence, and static contracts.

* **Documentation**
  * Added the Phase 1 PR-3 idempotency ADR, implementation plan, and E2E acceptance memo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->